### PR TITLE
Minimise downtime when reloading GeoNames data

### DIFF
--- a/k8s/geonames-sparql/geonames-harvester-cronjob.yml
+++ b/k8s/geonames-sparql/geonames-harvester-cronjob.yml
@@ -8,13 +8,17 @@ spec:
     spec:
       template:
         spec:
-          containers:
+          initContainers:
             - name: harvester
               image: ghcr.io/netwerk-digitaal-erfgoed/geonames-harvester
               command: ["/bin/sh", "-c", "./geonames-download.sh && ./map.sh"]
               volumeMounts:
                 - name: data
                   mountPath: /app/data
+          containers:
+            - name: restart
+              image: bitnami/kubectl:1.25.3
+              command: ["kubectl rollout restart statefulset/geonames-sparql"]
           restartPolicy: OnFailure
           volumes:
             - name: data

--- a/k8s/geonames-sparql/geonames-harvester-cronjob.yml
+++ b/k8s/geonames-sparql/geonames-harvester-cronjob.yml
@@ -8,6 +8,7 @@ spec:
     spec:
       template:
         spec:
+          serviceAccountName: statefulset-manager
           initContainers:
             - name: harvester
               image: ghcr.io/netwerk-digitaal-erfgoed/geonames-harvester
@@ -15,10 +16,11 @@ spec:
               volumeMounts:
                 - name: data
                   mountPath: /app/data
+          # Restart Fuseki to reload harvested data.
           containers:
             - name: restart
               image: bitnami/kubectl:1.25.3
-              command: ["kubectl rollout restart statefulset/geonames-sparql"]
+              args: ["rollout", "restart", "statefulset/geonames-sparql"]
           restartPolicy: OnFailure
           volumes:
             - name: data

--- a/k8s/geonames-sparql/geonames-sparql-stateful-set.yml
+++ b/k8s/geonames-sparql/geonames-sparql-stateful-set.yml
@@ -13,13 +13,6 @@ spec:
       labels:
         app: geonames-sparql
     spec:
-      initContainers:
-        - name: harvester
-          image: ghcr.io/netwerk-digitaal-erfgoed/geonames-harvester
-          command: ["/bin/sh", "-c", "./geonames-download.sh && ./map.sh"]
-          volumeMounts:
-            - name: data
-              mountPath: /app/data
       containers:
         - name: app
           image: atomgraph/fuseki:9985c4edd850c9277d241f6edc0d883013713ad3

--- a/k8s/geonames-sparql/geonames-sparql-stateful-set.yml
+++ b/k8s/geonames-sparql/geonames-sparql-stateful-set.yml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: atomgraph/fuseki:9985c4edd850c9277d241f6edc0d883013713ad3
+          image: atomgraph/fuseki:4.6.1
           args: ["--file=/data/geonames.nt", "/geonames"]
           ports:
             - containerPort: 3030

--- a/k8s/rbac/role-binding.yml
+++ b/k8s/rbac/role-binding.yml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: restart-statefulsets
+subjects:
+  - kind: ServiceAccount
+    name: statefulset-manager
+roleRef:
+  kind: Role
+  name: restart-statefulsets
+  apiGroup: rbac.authorization.k8s.io

--- a/k8s/rbac/roles.yml
+++ b/k8s/rbac/roles.yml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: restart-statefulsets
+rules:
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["get", "patch"]

--- a/k8s/rbac/service-account.yml
+++ b/k8s/rbac/service-account.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: statefulset-manager


### PR DESCRIPTION
- Remove init container which slows down boot too much
- Harvest GeoNames without downtime

Fix #38
