### PR TITLE
adding key usage for certificate requests

### DIFF
--- a/k8s/dataset-register-demo/ingress.yml
+++ b/k8s/dataset-register-demo/ingress.yml
@@ -4,6 +4,7 @@ metadata:
   name: dataset-register-demo
   annotations:
     cert-manager.io/issuer: harica-nde
+    cert-manager.io/usages: server auth,digital signature,client auth
 spec:
   tls:
     - hosts:

--- a/k8s/network-of-terms-demo/network-of-terms-demo-ingress.yml
+++ b/k8s/network-of-terms-demo/network-of-terms-demo-ingress.yml
@@ -5,6 +5,7 @@ metadata:
   name: network-of-terms-demo
   annotations:
     cert-manager.io/issuer: harica-nde
+    cert-manager.io/usages: server auth,digital signature,client auth
 spec:
   tls:
     - hosts:

--- a/k8s/openrefine/ingress.yml
+++ b/k8s/openrefine/ingress.yml
@@ -4,6 +4,7 @@ metadata:
   name: openrefine
   annotations:
     cert-manager.io/issuer: harica-nde
+    cert-manager.io/usages: server auth,digital signature,client auth
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
Fix for the certificate order failing:
Reason:           Failed to finalize Order: 400 urn:ietf:params:acme:error:badCSR: Requested key usage will not be granted.