### PR TITLE
fix(qlever-ui): preserve path and query string in redirect

### DIFF
--- a/k8s/qlever-ui/helmrelease.yaml
+++ b/k8s/qlever-ui/helmrelease.yaml
@@ -46,4 +46,4 @@ spec:
         tls:
           enabled: true
         annotations:
-          nginx.ingress.kubernetes.io/permanent-redirect: https://qlever.netwerkdigitaalerfgoed.nl
+          nginx.ingress.kubernetes.io/permanent-redirect: https://qlever.netwerkdigitaalerfgoed.nl$request_uri


### PR DESCRIPTION
## Summary

The redirect from `qlever-ui.demo.netwerkdigitaalerfgoed.nl` to `qlever.netwerkdigitaalerfgoed.nl` was not preserving the path or query string. This adds `$request_uri` to the nginx permanent-redirect annotation to preserve both.

## Changes

* Add `$request_uri` to the permanent-redirect annotation