### PR TITLE
refactor(helm): consolidate persistent volume configuration

### DIFF
--- a/helm/nde-app/README.md
+++ b/helm/nde-app/README.md
@@ -9,6 +9,59 @@ Generic Helm chart for deploying NDE applications. It supports:
 - ConfigMaps
 - CronJobs
 
+## Persistent Volumes
+
+Use `persistentVolumes` for storage. It works with all workload types:
+
+```yaml
+persistentVolumes:
+  - name: data
+    size: 50Gi
+    mountPath: /data          # Optional - only used for CronJob auto-wiring
+    storageClass: hdd         # Optional, defaults to hdd
+    accessMode: ReadWriteOnce # Optional, defaults to ReadWriteOnce
+```
+
+**Behavior by workload type:**
+
+| Workload | What's created |
+|----------|---------------|
+| StatefulSet | volumeClaimTemplates (manual volumeMounts in container) |
+| Deployment | PVC (manual volumes + volumeMounts in container) |
+| CronJob | PVC + volume + volumeMount (auto-wired if mountPath set) |
+
+**StatefulSet example** (manual volumeMounts):
+
+```yaml
+workload:
+  type: statefulset
+containers:
+  - name: app
+    image:
+      repository: postgres
+      tag: "16"
+    volumeMounts:
+      - name: data
+        mountPath: /var/lib/postgresql/data
+persistentVolumes:
+  - name: data
+    size: 50Gi
+```
+
+**CronJob example** (auto-wired):
+
+```yaml
+persistentVolumes:
+  - name: imports
+    size: 100Gi
+    mountPath: /app/imports   # Auto-creates volume + volumeMount
+cronjobs:
+  - name: importer
+    schedule: "0 4 * * *"
+    image: my-image:latest
+    # No volumes/volumeMounts needed - auto-wired from persistentVolumes
+```
+
 ## Flux Image Automation
 
 Flux image automation is **enabled by default** for all containers. This automatically updates image tags when new versions are pushed.
@@ -40,4 +93,36 @@ containers:
       policy:
         type: semver
         range: "~10.11"  # Only patch updates
+```
+
+## Ingresses
+
+The first ingress gets TLS auto-configured. Additional ingresses need explicit `tls.enabled: true`:
+
+```yaml
+ingresses:
+  - hosts:
+      - app.example.com
+    # First ingress: TLS enabled automatically
+  - name: redirect
+    hosts:
+      - old.example.com
+    tls:
+      enabled: true  # Required for non-first ingresses
+    annotations:
+      nginx.ingress.kubernetes.io/permanent-redirect: https://app.example.com
+```
+
+For regex paths, use `pathType: ImplementationSpecific`:
+
+```yaml
+ingresses:
+  - hosts:
+      - app.example.com
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: /$1
+      nginx.ingress.kubernetes.io/use-regex: "true"
+    paths:
+      - path: /api/(.*)
+        pathType: ImplementationSpecific  # Required for regex
 ```

--- a/helm/nde-app/templates/cronjob.yaml
+++ b/helm/nde-app/templates/cronjob.yaml
@@ -1,9 +1,10 @@
+{{- $fullname := include "nde-app.fullname" . }}
 {{- range .Values.cronjobs }}
 ---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "nde-app.fullname" $ }}-{{ required "cronjobs[].name is required" .name }}
+  name: {{ $fullname }}-{{ required "cronjobs[].name is required" .name }}
   labels:
     {{- include "nde-app.labels" $ | nindent 4 }}
 spec:
@@ -14,7 +15,7 @@ spec:
         metadata:
           labels:
             {{- include "nde-app.selectorLabels" $ | nindent 12 }}
-            app: {{ include "nde-app.fullname" $ }}-{{ .name }}
+            app: {{ $fullname }}-{{ .name }}
         spec:
           {{- if hasPrefix "ghcr.io" .image }}
           imagePullSecrets:
@@ -42,17 +43,44 @@ spec:
               env:
                 {{- toYaml . | nindent 16 }}
               {{- end }}
-              {{- with .volumeMounts }}
+              {{- /* Auto-generate volumeMounts from persistentVolumes with mountPath */ -}}
+              {{- $autoMounts := list }}
+              {{- range $.Values.persistentVolumes }}
+                {{- if .mountPath }}
+                  {{- $autoMounts = append $autoMounts (dict "name" .name "mountPath" .mountPath) }}
+                {{- end }}
+              {{- end }}
+              {{- if or .volumeMounts $autoMounts }}
               volumeMounts:
+                {{- with .volumeMounts }}
                 {{- toYaml . | nindent 16 }}
+                {{- end }}
+                {{- range $autoMounts }}
+                - name: {{ .name }}
+                  mountPath: {{ .mountPath }}
+                {{- end }}
               {{- end }}
               {{- with .resources }}
               resources:
                 {{- toYaml . | nindent 16 }}
               {{- end }}
-          {{- with .volumes }}
+          {{- /* Auto-generate volumes from persistentVolumes with mountPath */ -}}
+          {{- $autoVolumes := list }}
+          {{- range $.Values.persistentVolumes }}
+            {{- if .mountPath }}
+              {{- $autoVolumes = append $autoVolumes (dict "name" .name "persistentVolumeClaim" (dict "claimName" (printf "%s-%s" $fullname .name))) }}
+            {{- end }}
+          {{- end }}
+          {{- if or .volumes $autoVolumes }}
           volumes:
+            {{- with .volumes }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- range $autoVolumes }}
+            - name: {{ .name }}
+              persistentVolumeClaim:
+                claimName: {{ .persistentVolumeClaim.claimName }}
+            {{- end }}
           {{- end }}
           restartPolicy: {{ .restartPolicy | default "OnFailure" }}
 {{- end }}

--- a/helm/nde-app/templates/pvc.yaml
+++ b/helm/nde-app/templates/pvc.yaml
@@ -1,9 +1,11 @@
-{{- range .Values.pvcs }}
+{{- /* Generate PVCs for Deployments (not StatefulSets) from persistentVolumes */ -}}
+{{- if and (ne .Values.workload.type "statefulset") .Values.persistentVolumes }}
+{{- range .Values.persistentVolumes }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "nde-app.fullname" $ }}-{{ required "pvcs[].name is required" .name }}
+  name: {{ include "nde-app.fullname" $ }}-{{ required "persistentVolumes[].name is required" .name }}
   labels:
     {{- include "nde-app.labels" $ | nindent 4 }}
 spec:
@@ -12,5 +14,6 @@ spec:
   storageClassName: {{ .storageClass | default "hdd" }}
   resources:
     requests:
-      storage: {{ required "pvcs[].size is required" .size }}
+      storage: {{ required "persistentVolumes[].size is required" .size }}
+{{- end }}
 {{- end }}

--- a/helm/nde-app/templates/workload.yaml
+++ b/helm/nde-app/templates/workload.yaml
@@ -1,9 +1,11 @@
 {{- if .Values.containers }}
 {{- $kind := eq .Values.workload.type "statefulset" | ternary "StatefulSet" "Deployment" }}
+{{- $isStatefulSet := eq .Values.workload.type "statefulset" }}
+{{- $fullname := include "nde-app.fullname" . }}
 apiVersion: apps/v1
 kind: {{ $kind }}
 metadata:
-  name: {{ include "nde-app.fullname" . }}
+  name: {{ $fullname }}
   labels:
     {{- include "nde-app.labels" . | nindent 4 }}
 spec:
@@ -11,8 +13,8 @@ spec:
   selector:
     matchLabels:
       {{- include "nde-app.selectorLabels" . | nindent 6 }}
-  {{- if eq .Values.workload.type "statefulset" }}
-  serviceName: {{ include "nde-app.fullname" . }}
+  {{- if $isStatefulSet }}
+  serviceName: {{ $fullname }}
   {{- end }}
   template:
     metadata:
@@ -23,7 +25,7 @@ spec:
       {{- end }}
       labels:
         {{- include "nde-app.selectorLabels" . | nindent 8 }}
-        app: {{ include "nde-app.fullname" . }}
+        app: {{ $fullname }}
     spec:
       {{- $needsGhcr := false }}
       {{- range .Values.containers }}
@@ -74,19 +76,8 @@ spec:
       volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-  {{- if and (eq .Values.workload.type "statefulset") (or .Values.persistence.enabled .Values.persistentVolumes) }}
+  {{- if and $isStatefulSet .Values.persistentVolumes }}
   volumeClaimTemplates:
-    {{- if .Values.persistence.enabled }}
-    - metadata:
-        name: {{ .Values.persistence.name }}
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: {{ .Values.persistence.size }}
-        storageClassName: {{ .Values.persistence.storageClass }}
-    {{- end }}
     {{- range .Values.persistentVolumes }}
     - metadata:
         name: {{ .name }}

--- a/helm/nde-app/values.yaml
+++ b/helm/nde-app/values.yaml
@@ -67,26 +67,15 @@ volumes: []
   #   configMap:
   #     name: my-config
 
-# Persistence (StatefulSet only) - single volume
-persistence:
-  enabled: false
-  storageClass: hdd
-  size: 1Gi
-  name: data
-  mountPath: /data
-
-# Multiple persistent volumes (StatefulSet only)
+# Persistent volumes - unified storage for all workload types
+# For StatefulSets: creates volumeClaimTemplates
+# For Deployments/CronJobs: creates PVC + volume + volumeMount
 persistentVolumes: []
   # - name: data
   #   size: 50Gi
-  #   storageClass: hdd  # optional, defaults to hdd
-
-# PersistentVolumeClaims
-pvcs: []
-  # - name: data            # Required, used in PVC name (fullname-name)
-  #   size: 1Gi             # Required
-  #   accessMode: ReadWriteOnce  # Optional, defaults to ReadWriteOnce
-  #   storageClass: hdd      # Optional, defaults to hdd
+  #   mountPath: /data          # Optional - auto-wires volumeMount if provided
+  #   storageClass: hdd         # Optional, defaults to hdd
+  #   accessMode: ReadWriteOnce # Optional, defaults to ReadWriteOnce
 
 # ConfigMaps
 configMaps: []

--- a/k8s/annorepo/helmrelease-mongo.yaml
+++ b/k8s/annorepo/helmrelease-mongo.yaml
@@ -18,7 +18,7 @@ spec:
       type: statefulset
 
     containers:
-      - name: annorepo-mongo
+      - name: app
         image:
           repository: mongo
           tag: "8.0.9"
@@ -34,9 +34,6 @@ spec:
     service:
       port: 27017
 
-    persistence:
-      enabled: true
-      name: data
-      mountPath: /data/db
-      size: 8Gi
-      storageClass: hdd
+    persistentVolumes:
+      - name: data
+        size: 8Gi

--- a/k8s/dataset-knowledge-graph/helmrelease.yaml
+++ b/k8s/dataset-knowledge-graph/helmrelease.yaml
@@ -13,9 +13,10 @@ spec:
         kind: GitRepository
         name: nde
   values:
-    pvcs:
+    persistentVolumes:
       - name: imports
         size: 500Gi
+        mountPath: /app/imports
     cronjobs:
       - name: app
         schedule: "15 3 * * *"
@@ -38,13 +39,6 @@ spec:
               secretKeyRef:
                 name: graphdb
                 key: password
-        volumeMounts:
-          - mountPath: /app/imports
-            name: imports
-        volumes:
-          - name: imports
-            persistentVolumeClaim:
-              claimName: dataset-knowledge-graph-imports
         resources:
           requests:
             cpu: "2"

--- a/k8s/dataset-register-demo/helmrelease.yaml
+++ b/k8s/dataset-register-demo/helmrelease.yaml
@@ -46,6 +46,6 @@ spec:
         paths:
           - path: /register(/|$)(.*)
             pathType: ImplementationSpecific
-    persistence:
-      enabled: true
-      mountPath: /datasetdescriptions
+    persistentVolumes:
+      - name: data
+        size: 1Gi


### PR DESCRIPTION
## Summary

* Unify `persistence`, `pvcs`, and `persistentVolumes` into a single `persistentVolumes` config
* Add optional `mountPath` for auto-wiring volumeMounts in Deployments and CronJobs
* StatefulSets continue to use volumeClaimTemplates (manual volumeMounts in container)
* Deployments/CronJobs auto-create PVC + volume + volumeMount when `mountPath` is set

## Changes

- **helm/nde-app**: Consolidated storage configuration, updated templates and docs
- **k8s/annorepo/helmrelease-mongo.yaml**: Migrated from `persistence:` to `persistentVolumes:`
- **k8s/dataset-knowledge-graph/helmrelease.yaml**: Removed manual volumes/volumeMounts/claimName boilerplate
- **k8s/dataset-register-demo/helmrelease.yaml**: Migrated from `persistence:` to `persistentVolumes:`

## Example

Before (CronJob with storage):
```yaml
pvcs:
  - name: imports
    size: 500Gi
cronjobs:
  - name: app
    volumeMounts:
      - mountPath: /app/imports
        name: imports
    volumes:
      - name: imports
        persistentVolumeClaim:
          claimName: dataset-knowledge-graph-imports
```

After:
```yaml
persistentVolumes:
  - name: imports
    size: 500Gi
    mountPath: /app/imports
cronjobs:
  - name: app
    # volumeMounts and volumes auto-generated
```