### PR TITLE
feat: add Matomo analytics service

### DIFF
--- a/k8s/matomo/helmrelease.yaml
+++ b/k8s/matomo/helmrelease.yaml
@@ -1,0 +1,35 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: matomo
+  namespace: nde
+spec:
+  serviceAccountName: nde
+  interval: 30m
+  chart:
+    spec:
+      chart: matomo
+      version: ">=4.0.0 <5.0.0"
+      sourceRef:
+        kind: HelmRepository
+        name: bitnami
+        namespace: nde
+  values:
+    ingress:
+      enabled: true
+      hostname: matomo.netwerkdigitaalerfgoed.nl
+      tls: true
+      annotations:
+        cert-manager.io/issuer: harica-nde
+        cert-manager.io/usages: server auth,digital signature,client auth
+    persistence:
+      storageClass: hdd
+      size: 10Gi
+    mariadb:
+      auth:
+        existingSecret: matomo-mariadb
+        database: matomo
+      primary:
+        persistence:
+          storageClass: hdd
+          size: 8Gi

--- a/k8s/matomo/helmrepository.yaml
+++ b/k8s/matomo/helmrepository.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: bitnami
+  namespace: nde
+spec:
+  type: oci
+  interval: 24h
+  url: oci://registry-1.docker.io/bitnamicharts

--- a/k8s/secrets/matomo-mariadb.yaml
+++ b/k8s/secrets/matomo-mariadb.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+data:
+    mariadb-password: ENC[AES256_GCM,data:IsWW+vt90V+7ko29O9k83hDOUon4MaDt9x8Gt5AE+W/LJ/hKgaflDaVDLKI=,iv:R0IoBFmz/WR7RpknB2odAo+MTWrdzIjd6eKisSlYD8M=,tag:47gMGmSoeFSNYnzuaQsl5w==,type:str]
+    mariadb-root-password: ENC[AES256_GCM,data:7Y40SysZ8JfudGd1677amoGGHYk/I09EEIhoLhqj2GcZv2veURv2EumfCJw=,iv:JKqJnHUYE6nrZOZwYO13+1CMRFqUIjqCZGFuILA3xp8=,tag:SHaNbsFYZtX92Y84c2DpYw==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: matomo-mariadb
+    namespace: nde
+sops:
+    age:
+        - recipient: age1qnjmyern7zmm5wpsclrpexu327xuqalpcthuk32hj8xn5ssts96s5hhhu8
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjOVlxSzl0dGgwMEM5Q3Za
+            dU9IQmdxZWZGRFBrL0ZhendWZE04aFAvaHlFClVwWXZEZW9mbUdqb200SkdTM21N
+            OHloNFN1STlDN0c0SWllY0dIdUFFN3cKLS0tIGR1NVhhNHdHUEVZQTg2SHRLOXNZ
+            cVU4cjVKYk40ak1kMTR5VmR2WW1jYm8KJlmtgBoCk4jbswwVbWXXF7ytD2TASU0E
+            LCFG/Qh5AK4CMbi5aFiHOZWOpCF0r77AF5e3FTVeNbRzOzcjaWcMUQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-12-17T11:09:45Z"
+    mac: ENC[AES256_GCM,data:CiCIdby/vlU22cWy5cz1wzkBYCIyQ8HvylC1aeBUz8VJ+cwxUACYCXQaLf6h9GrxcUQG8S0v5MT/ZjkViAuSNW9I8iSYohgVAAdK32D8k7z1saw11y0Nj0a0K0yk5XBuIR33PVQq3L3HjgHQCkLu/ank5vjPdnqsz8O7X9cTAxU=,iv:A9dHnW//txBS2DxQPNDND8dFsjiOKRnCJf6/iQp6eBc=,tag:hXLeYBTXdEo4XqUq2rmrxw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2


### PR DESCRIPTION
## Summary
* Add Matomo analytics service using Bitnami Helm chart
* MariaDB database bundled with the chart
* Ingress configured at `matomo.netwerkdigitaalerfgoed.nl` with HARICA TLS

## Changes
* `k8s/matomo/helmrelease.yaml` - Matomo HelmRelease using Bitnami chart
* `k8s/matomo/helmrepository.yaml` - Bitnami OCI HelmRepository
* `k8s/secrets/matomo-mariadb.yaml` - SOPS-encrypted MariaDB credentials