### PR TITLE
fix(matomo): update Bitnami chart version constraint

### DIFF
--- a/k8s/matomo/helmrelease.yaml
+++ b/k8s/matomo/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: matomo
-      version: ">=4.0.0 <5.0.0"
+      version: ">=11.0.0 <12.0.0"
       sourceRef:
         kind: HelmRepository
         name: bitnami


### PR DESCRIPTION
## Summary
Fix Matomo deployment failing due to missing MariaDB image.

## Problem
The version constraint `>=4.0.0 <5.0.0` matched old chart versions (4.x) that reference MariaDB images no longer available on Docker Hub:
```
Failed to pull image "docker.io/bitnami/mariadb:11.2.2-debian-11-r0": not found
```

## Fix
Update version constraint to `>=11.0.0 <12.0.0` to use the current Bitnami Matomo chart (11.0.0) with available images.