### PR TITLE
Add TLS proxy support for DERA

### DIFF
--- a/helm/nde-app/templates/service.yaml
+++ b/helm/nde-app/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.containers }}
+{{- if or .Values.containers .Values.externalService.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -7,7 +7,10 @@ metadata:
     {{- include "nde-app.labels" . | nindent 4 }}
 spec:
   ports:
-    {{- if .Values.service.ports }}
+    {{- if .Values.externalService.enabled }}
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.externalService.port }}
+    {{- else if .Values.service.ports }}
     {{- range .Values.service.ports }}
     - name: {{ .name }}
       port: {{ .port }}
@@ -17,6 +20,22 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort | default (index .Values.containers 0).port }}
     {{- end }}
+  {{- if not .Values.externalService.enabled }}
   selector:
     {{- include "nde-app.selectorLabels" . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- if .Values.externalService.enabled }}
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: {{ include "nde-app.fullname" . }}
+  labels:
+    {{- include "nde-app.labels" . | nindent 4 }}
+subsets:
+  - addresses:
+      - ip: {{ .Values.externalService.ip }}
+    ports:
+      - port: {{ .Values.externalService.port }}
 {{- end }}

--- a/helm/nde-app/values.yaml
+++ b/helm/nde-app/values.yaml
@@ -3,6 +3,12 @@ workload:
   type: deployment  # or "statefulset"
   replicas: 1
 
+# External service (reverse proxy to external IP, no containers needed)
+externalService:
+  enabled: false
+  ip: ""
+  port: 80
+
 # Container(s) - supports multi-container pods
 containers: []
 # Example:

--- a/k8s/dera/helmrelease.yaml
+++ b/k8s/dera/helmrelease.yaml
@@ -1,0 +1,22 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dera
+spec:
+  serviceAccountName: nde
+  interval: 30m
+  chart:
+    spec:
+      chart: helm/nde-app
+      reconcileStrategy: Revision
+      sourceRef:
+        kind: GitRepository
+        name: nde
+  values:
+    externalService:
+      enabled: true
+      ip: 84.22.101.57
+      port: 80
+    ingresses:
+      - hosts:
+          - dera.netwerkdigitaalerfgoed.nl


### PR DESCRIPTION
## Summary
* Add `externalService` option to nde-app Helm chart for reverse proxy use cases
* Create Service without selector + Endpoints pointing to external IP when enabled
* Deploy DERA TLS proxy: terminates HTTPS at `dera.netwerkdigitaalerfgoed.nl`, proxies HTTP to `84.22.101.57`

## How it works
The new `externalService` config creates a Kubernetes Service without a selector, paired with an Endpoints resource pointing to an external IP. This allows the ingress to terminate TLS and proxy traffic to a service hosted outside the cluster.

## Test plan
- [ ] Verify `helm template` generates correct Service, Endpoints, and Ingress
- [ ] Point DNS for `dera.netwerkdigitaalerfgoed.nl` to cluster ingress IP
- [ ] Verify TLS certificate is issued and HTTPS works