### PR TITLE
fix(matomo): force MariaDB pod recreation

### DIFF
--- a/k8s/matomo/helmrelease.yaml
+++ b/k8s/matomo/helmrelease.yaml
@@ -30,6 +30,8 @@ spec:
         existingSecret: matomo-mariadb
         database: matomo
       primary:
+        podAnnotations:
+          recreate-trigger: "1"
         persistence:
           storageClass: hdd
           size: 8Gi


### PR DESCRIPTION
## Summary
Force MariaDB StatefulSet pod recreation to resolve stuck pod with unavailable image.

## Problem
The MariaDB pod is stuck trying to pull an image that no longer exists on Docker Hub (`mariadb:11.2.2-debian-11-r0`).

## Fix
Add `podAnnotations` to trigger pod recreation, which will use the new image from the updated chart.