### PR TITLE
Fix DERA proxy: use HTTPS to backend

### DIFF
--- a/k8s/dera/helmrelease.yaml
+++ b/k8s/dera/helmrelease.yaml
@@ -16,7 +16,9 @@ spec:
     externalService:
       enabled: true
       ip: 84.22.101.57
-      port: 80
+      port: 443
     ingresses:
       - hosts:
           - dera.netwerkdigitaalerfgoed.nl
+        annotations:
+          nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"


### PR DESCRIPTION
## Summary
* Backend at 84.22.101.57 redirects HTTP→HTTPS, causing infinite redirect loop
* Change externalService port from 80 to 443
* Add `backend-protocol: HTTPS` annotation for nginx ingress

## Note
Temporary fix until backend admin disables HTTPS redirect.