### PR TITLE
refactor(matomo): migrate from Bitnami chart to nde-app

### DIFF
--- a/k8s/matomo/helmrelease-mariadb.yaml
+++ b/k8s/matomo/helmrelease-mariadb.yaml
@@ -1,0 +1,58 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: matomo-mariadb
+  namespace: nde
+spec:
+  serviceAccountName: nde
+  interval: 30m
+  chart:
+    spec:
+      chart: helm/nde-app
+      reconcileStrategy: Revision
+      sourceRef:
+        kind: GitRepository
+        name: nde
+  values:
+    workload:
+      type: statefulset
+
+    containers:
+      - name: mariadb
+        image:
+          repository: mariadb
+          tag: "11.6.2"
+        port: 3306
+        flux:
+          policy:
+            type: semver
+            range: "~11.6"
+        env:
+          - name: MARIADB_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: matomo-mariadb
+                key: mariadb-root-password
+          - name: MARIADB_USER
+            valueFrom:
+              secretKeyRef:
+                name: matomo-mariadb
+                key: mariadb-user
+          - name: MARIADB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: matomo-mariadb
+                key: mariadb-password
+          - name: MARIADB_DATABASE
+            value: matomo
+        volumeMounts:
+          - name: data
+            mountPath: /var/lib/mysql
+
+    persistentVolumes:
+      - name: data
+        size: 8Gi
+
+    service:
+      port: 3306
+      targetPort: 3306

--- a/k8s/matomo/helmrelease.yaml
+++ b/k8s/matomo/helmrelease.yaml
@@ -8,30 +8,102 @@ spec:
   interval: 30m
   chart:
     spec:
-      chart: matomo
-      version: ">=11.0.0 <12.0.0"
+      chart: helm/nde-app
+      reconcileStrategy: Revision
       sourceRef:
-        kind: HelmRepository
-        name: bitnami
-        namespace: nde
+        kind: GitRepository
+        name: nde
   values:
-    ingress:
-      enabled: true
-      hostname: matomo.netwerkdigitaalerfgoed.nl
-      tls: true
-      annotations:
-        cert-manager.io/issuer: harica-nde
-        cert-manager.io/usages: server auth,digital signature,client auth
-    persistence:
-      storageClass: hdd
-      size: 10Gi
-    mariadb:
-      auth:
-        existingSecret: matomo-mariadb
-        database: matomo
-      primary:
-        podAnnotations:
-          recreate-trigger: "1"
-        persistence:
-          storageClass: hdd
-          size: 8Gi
+    workload:
+      type: statefulset
+
+    containers:
+      - name: nginx
+        image:
+          repository: nginx
+          tag: "1.27-alpine"
+        port: 80
+        flux:
+          policy:
+            type: semver
+            range: "~1"
+        volumeMounts:
+          - name: data
+            mountPath: /var/www/html
+            readOnly: true
+          - name: nginx-config
+            mountPath: /etc/nginx/conf.d
+
+      - name: php-fpm
+        image:
+          repository: matomo
+          tag: "5-fpm-alpine"
+        port: 9000
+        flux:
+          policy:
+            type: semver
+            range: "~5"
+        env:
+          - name: MATOMO_DATABASE_HOST
+            value: matomo-mariadb
+          - name: MATOMO_DATABASE_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: matomo-mariadb
+                key: mariadb-user
+          - name: MATOMO_DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: matomo-mariadb
+                key: mariadb-password
+          - name: MATOMO_DATABASE_DBNAME
+            value: matomo
+        volumeMounts:
+          - name: data
+            mountPath: /var/www/html
+
+    securityContext:
+      fsGroup: 82
+
+    persistentVolumes:
+      - name: data
+        size: 10Gi
+
+    volumes:
+      - name: nginx-config
+        configMap:
+          name: matomo-nginx
+
+    configMaps:
+      - name: nginx
+        data:
+          default.conf: |
+            server {
+                listen 80;
+                server_name _;
+                root /var/www/html;
+                index index.php;
+
+                client_max_body_size 50m;
+
+                location / {
+                    try_files $uri $uri/ /index.php?$query_string;
+                }
+
+                location ~ \.php$ {
+                    fastcgi_pass 127.0.0.1:9000;
+                    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+                    include fastcgi_params;
+                }
+
+                location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+                    expires 1y;
+                    add_header Cache-Control "public, immutable";
+                }
+            }
+
+    ingresses:
+      - hosts:
+          - matomo.netwerkdigitaalerfgoed.nl
+        annotations:
+          nginx.ingress.kubernetes.io/proxy-body-size: "50m"


### PR DESCRIPTION
## Summary

Migrate Matomo from Bitnami Helm chart to nde-app chart using official Docker images. This addresses Broadcom's monetization of Bitnami images which removed versioned tags from Docker Hub.

* Replace Bitnami Matomo chart with nde-app chart
* Use `nginx:alpine` + `matomo:fpm-alpine` for smallest image footprint (~244MB vs ~740MB+)
* Add separate MariaDB helmrelease using official `mariadb` image
* Configure Flux semver policies for automatic image updates
* Add nginx ConfigMap for PHP-FPM proxy configuration

## Required secret

The `matomo-mariadb` secret needs these keys:
- `mariadb-root-password`
- `mariadb-user`
- `mariadb-password`