### PR TITLE
fix(matomo): add missing mariadb-user key to secret

### DIFF
--- a/k8s/secrets/matomo-mariadb.yaml
+++ b/k8s/secrets/matomo-mariadb.yaml
@@ -1,24 +1,24 @@
 apiVersion: v1
-data:
-    mariadb-password: ENC[AES256_GCM,data:IsWW+vt90V+7ko29O9k83hDOUon4MaDt9x8Gt5AE+W/LJ/hKgaflDaVDLKI=,iv:R0IoBFmz/WR7RpknB2odAo+MTWrdzIjd6eKisSlYD8M=,tag:47gMGmSoeFSNYnzuaQsl5w==,type:str]
-    mariadb-root-password: ENC[AES256_GCM,data:7Y40SysZ8JfudGd1677amoGGHYk/I09EEIhoLhqj2GcZv2veURv2EumfCJw=,iv:JKqJnHUYE6nrZOZwYO13+1CMRFqUIjqCZGFuILA3xp8=,tag:SHaNbsFYZtX92Y84c2DpYw==,type:str]
 kind: Secret
 metadata:
-    creationTimestamp: null
     name: matomo-mariadb
     namespace: nde
+stringData:
+    mariadb-root-password: ENC[AES256_GCM,data:oPxubnv1DtJtJ16BV564ebtGGhw6RW8eRGlnXefNqwdyvcKzGlxwNt90EFA=,iv:wLmWeglviIzPMEVhq7vWdK3t8X+eceNRwFgsrlSPSqU=,tag:yVd8ODar7EdgdbwULcl4IQ==,type:str]
+    mariadb-user: ENC[AES256_GCM,data:GF9Q4Nst,iv:xAcEVz96hd7MOuydrXXIDxnuX5Qimxu5V5WGDX3dN2c=,tag:W/lf//fbusaen06RAMqWog==,type:str]
+    mariadb-password: ENC[AES256_GCM,data:c7HnghDoSQAgXAWcvmjBHcPt6ReHy2X6/eT6PeCx4UI5U3jOY1G2jnSZasg=,iv:NiXVDGPAiLkgjTnUMbFx/eCXyjgJ11GUazPlxq/v3SI=,tag:XygxHV/WO3EOhSR3nnUpcQ==,type:str]
 sops:
     age:
         - recipient: age1qnjmyern7zmm5wpsclrpexu327xuqalpcthuk32hj8xn5ssts96s5hhhu8
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjOVlxSzl0dGgwMEM5Q3Za
-            dU9IQmdxZWZGRFBrL0ZhendWZE04aFAvaHlFClVwWXZEZW9mbUdqb200SkdTM21N
-            OHloNFN1STlDN0c0SWllY0dIdUFFN3cKLS0tIGR1NVhhNHdHUEVZQTg2SHRLOXNZ
-            cVU4cjVKYk40ak1kMTR5VmR2WW1jYm8KJlmtgBoCk4jbswwVbWXXF7ytD2TASU0E
-            LCFG/Qh5AK4CMbi5aFiHOZWOpCF0r77AF5e3FTVeNbRzOzcjaWcMUQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhZnNBV3gzT3B1Wm9vQXVq
+            ekY4V2lDRUNZZnlCU1htNE9nY2RtemZxRFNzCjQ2Y0xsWjBocW9jMEQwSGZXa1B6
+            aXg3b3lYYlgwRHl2Q2NvV09OQ0Z5U1UKLS0tIGxabUk2NzVPY1NEb1dhZmdORkVx
+            Q1JrZWJpUElsN0lwS3F3MkhKYUJ5cVkKIVBnu76mTOJ8/IpGfs19d/gbG3JI+IbT
+            EN3Ili0G2Wp+eoXdSeoUYjZqgL8MuJwjAloYQpqOYrbQQ9SFri2LPg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-12-17T11:09:45Z"
-    mac: ENC[AES256_GCM,data:CiCIdby/vlU22cWy5cz1wzkBYCIyQ8HvylC1aeBUz8VJ+cwxUACYCXQaLf6h9GrxcUQG8S0v5MT/ZjkViAuSNW9I8iSYohgVAAdK32D8k7z1saw11y0Nj0a0K0yk5XBuIR33PVQq3L3HjgHQCkLu/ank5vjPdnqsz8O7X9cTAxU=,iv:A9dHnW//txBS2DxQPNDND8dFsjiOKRnCJf6/iQp6eBc=,tag:hXLeYBTXdEo4XqUq2rmrxw==,type:str]
+    lastmodified: "2025-12-17T14:27:56Z"
+    mac: ENC[AES256_GCM,data:J4qIDEv9QN7kp9RXa43By3wentNtPJuntpi+zAU7eUQo/et6oBd6BhB2vShOKLX3G1VCiqErugXtKIa+DXrldEjyfwbBw13eOUEeW8lO6F/EfSIA56T1ukF+lscxhdwsDDUO+0D62oDIkP/etZNJ3UMmq7eMXLHDK3klmEIn3Go=,iv:T9P3c5Qcu0GQ67P8GpK7N6uyLPmrGyofSNvM53Zfw3Y=,tag:dVH6yvXG5bPdNYI0xeiIdg==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.10.2


### PR DESCRIPTION
## Summary
* Add missing `mariadb-user` key required by the nde-app chart HelmRelease
* Regenerate secret with new credentials for fresh MariaDB setup

## Context
The Matomo MariaDB HelmRelease failed because the secret was missing the `mariadb-user` key that the container expects.