### PR TITLE
fix(matomo): move MariaDB from EOL 11.6 to 11.4 LTS

### DIFF
--- a/k8s/matomo/helmrelease-mariadb.yaml
+++ b/k8s/matomo/helmrelease-mariadb.yaml
@@ -21,12 +21,12 @@ spec:
       - name: mariadb
         image:
           repository: mariadb
-          tag: "11.6.2"
+          tag: "11.4.9"
         port: 3306
         flux:
           policy:
             type: semver
-            range: "~11.6"
+            range: "~11.4"
         env:
           - name: MARIADB_ROOT_PASSWORD
             valueFrom:


### PR DESCRIPTION
## Summary

* Upgrade MariaDB from 11.6.2 (EOL) to 11.4.9 LTS
* MariaDB 11.6 was a rolling release that has reached End of Life
* MariaDB 11.4 LTS is supported until May 2029

## Changes

* Update image tag from `11.6.2` to `11.4.9`
* Update Flux semver policy from `~11.6` to `~11.4` for automatic patch updates