### PR TITLE
fix(omeka-s-faq): upgrade MariaDB from 10.11 to 11.4 LTS

### DIFF
--- a/k8s/omeka-s-faq/helmrelease-mysql.yaml
+++ b/k8s/omeka-s-faq/helmrelease-mysql.yaml
@@ -21,12 +21,12 @@ spec:
       - name: mariadb
         image:
           repository: mariadb
-          tag: "10.11.3"
+          tag: "11.4.9"
         port: 3306
         flux:
           policy:
             type: semver
-            range: "~10.11"
+            range: "~11.4"
         env:
           - name: MYSQL_ROOT_PASSWORD
             valueFrom:


### PR DESCRIPTION
## Summary

* Upgrade MariaDB from 10.11.3 (rolling release) to 11.4.9 LTS
* MariaDB 10.11 is not an LTS version
* MariaDB 11.4 LTS is supported until May 2029

## Changes

* Update image tag from `10.11.3` to `11.4.9`
* Update Flux semver policy from `~10.11` to `~11.4` for automatic patch updates