### PR TITLE
fix(matomo): harden nginx config per official security guidelines

### DIFF
--- a/k8s/matomo/helmrelease.yaml
+++ b/k8s/matomo/helmrelease.yaml
@@ -86,14 +86,41 @@ spec:
 
                 client_max_body_size 50m;
 
-                location / {
-                    try_files $uri $uri/ /index.php?$query_string;
+                add_header Referrer-Policy origin always;
+                add_header X-Content-Type-Options "nosniff" always;
+                add_header X-XSS-Protection "1; mode=block" always;
+
+                # Deny access to sensitive directories
+                location ~ ^/(config|tmp|core|lang) {
+                    deny all;
+                    return 404;
                 }
 
-                location ~ \.php$ {
+                location ~ ^/(libs|vendor|plugins|misc|node_modules) {
+                    deny all;
+                    return 404;
+                }
+
+                location ~ /\.ht {
+                    deny all;
+                    return 404;
+                }
+
+                location / {
+                    try_files $uri $uri/ =404;
+                }
+
+                # Only allow specific PHP files to execute
+                location ~ ^/(index|matomo|piwik|js/index|plugins/HeatmapSessionRecording/configs)\.php$ {
                     fastcgi_pass 127.0.0.1:9000;
                     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
                     include fastcgi_params;
+                }
+
+                # Deny all other PHP files
+                location ~* ^.+\.php$ {
+                    deny all;
+                    return 404;
                 }
 
                 location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {


### PR DESCRIPTION
## Summary

Fixes critical security issues reported by Matomo's system check:
- `/config/config.ini.php` and `/tmp/cache/` directories were publicly accessible
- Matomo's config directory was publicly accessible

## Changes

* Block access to sensitive directories (config, tmp, core, lang, libs, vendor, plugins, misc, node_modules)
* Restrict PHP execution to only allowed files (index.php, matomo.php, piwik.php, js/index.php, HeatmapSessionRecording)
* Add security headers (Referrer-Policy, X-Content-Type-Options, X-XSS-Protection)
* Return 404 for blocked paths to hide their existence

Based on official [matomo-nginx](https://github.com/matomo-org/matomo-nginx) configuration guidelines.