### PR TITLE
fix(helm): handle hostnames exceeding 64-char CN limit

### DIFF
--- a/helm/nde-app/templates/ingress.yaml
+++ b/helm/nde-app/templates/ingress.yaml
@@ -16,6 +16,10 @@ metadata:
     {{- with $.Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+    {{- $firstHost := index $ingress.hosts 0 }}
+    {{- if gt (len $firstHost) 64 }}
+    cert-manager.io/common-name: ""
+    {{- end }}
     {{- end }}
     {{- with $ingress.annotations }}
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
## Summary

X.509 certificates have a 64-character limit on the Common Name (CN) field. This caused TLS certificate issuance to fail for long hostnames like `heritageflix-zuiderzeemuseum-locaties.demo.netwerkdigitaalerfgoed.nl` (70 characters).

## Changes

* When the first hostname exceeds 64 characters, adds `cert-manager.io/common-name: ""` annotation
* This instructs cert-manager to omit the CN and use only Subject Alternative Names (SANs)
* Modern TLS clients validate hostnames via SAN, so empty CN is fully supported

## Test plan

* Verified with `helm template` that short hostnames don't get the annotation
* Verified with `helm template` that long hostnames get `cert-manager.io/common-name: ""`
* `helm lint` passes