### PR TITLE
fix(helm): use truncated hostname for CN instead of empty value

### DIFF
--- a/helm/nde-app/templates/ingress.yaml
+++ b/helm/nde-app/templates/ingress.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- end }}
     {{- $firstHost := index $ingress.hosts 0 }}
     {{- if gt (len $firstHost) 64 }}
-    cert-manager.io/common-name: ""
+    cert-manager.io/common-name: {{ $firstHost | trunc 64 | quote }}
     {{- end }}
     {{- end }}
     {{- with $ingress.annotations }}


### PR DESCRIPTION
## Summary

Follow-up to #121. Empty `cert-manager.io/common-name` annotation didn't work - cert-manager still failed to issue the certificate.

## Changes

* Use truncated hostname (first 64 chars) as CN instead of empty value
* Example: `heritageflix-zuiderzeemuseum-locaties.demo.netwerkdigitaalerfgoe`
* Full hostname remains in SAN (Subject Alternative Name) for TLS validation
* Modern TLS clients validate via SAN, so truncated CN is fine