### PR TITLE
fix(flux): add patch version to postgres semver extraction

### DIFF
--- a/k8s/makemyflix/helmrelease-postgres.yaml
+++ b/k8s/makemyflix/helmrelease-postgres.yaml
@@ -27,7 +27,7 @@ spec:
           policy:
             type: semver
             pattern: '^(?P<version>\d+\.\d+)-alpine$'
-            extract: '$version'
+            extract: '$version.0'
             range: "~16"
         env:
           - name: POSTGRES_PASSWORD


### PR DESCRIPTION
## Summary

* Fix ImagePolicy failing with "unable to determine latest version from provided list"
* Flux's `ParseVersion` requires 3-part semver (major.minor.patch)
* Postgres tags like `16.11-alpine` extract to `16.11`, which is rejected
* Append `.0` to extracted version to create valid semver `16.11.0`