### PR TITLE
fix(matomo): use prerelease-aware semver ranges for suffixed tags

### DIFF
--- a/helm/nde-app/templates/flux-image-policy.yaml
+++ b/helm/nde-app/templates/flux-image-policy.yaml
@@ -22,10 +22,12 @@ spec:
     numerical:
       order: {{ (((.flux).policy).order) | default "asc" }}
   {{- else if eq $policyType "semver" }}
-  {{- if or (((.flux).policy).pattern) (((.flux).policy).extract) }}
+  {{- if (((.flux).policy).pattern) }}
   filterTags:
     pattern: {{ (((.flux).policy).pattern) | squote }}
+    {{- if (((.flux).policy).extract) }}
     extract: {{ (((.flux).policy).extract) | squote }}
+    {{- end }}
   {{- end }}
   policy:
     semver:

--- a/k8s/matomo/helmrelease.yaml
+++ b/k8s/matomo/helmrelease.yaml
@@ -25,9 +25,8 @@ spec:
         flux:
           policy:
             type: semver
-            pattern: '^(?P<version>\d+\.\d+\.\d+)-alpine$'
-            extract: '$version'
-            range: "~1"
+            pattern: '^\d+\.\d+\.\d+-alpine$'
+            range: "~1.0.0-0"
         volumeMounts:
           - name: data
             mountPath: /var/www/html
@@ -42,9 +41,8 @@ spec:
         flux:
           policy:
             type: semver
-            pattern: '^(?P<version>\d+\.\d+\.\d+)-fpm-alpine$'
-            extract: '$version'
-            range: "~5"
+            pattern: '^\d+\.\d+\.\d+-fpm-alpine$'
+            range: "~5.0.0-0"
         env:
           - name: MATOMO_DATABASE_HOST
             value: matomo-mariadb

--- a/k8s/matomo/helmrepository.yaml
+++ b/k8s/matomo/helmrepository.yaml
@@ -1,9 +1,0 @@
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
-metadata:
-  name: bitnami
-  namespace: nde
-spec:
-  type: oci
-  interval: 24h
-  url: oci://registry-1.docker.io/bitnamicharts


### PR DESCRIPTION
## Summary

Fixes Matomo pod crash caused by Flux writing extracted semver version (`5.6.2`) instead of full Docker tag (`5.6.2-fpm-alpine`).

## Problem

Flux image automation with suffixed tags has two issues:
1. **Without `extract`**: Tags like `5.6.2-fpm-alpine` are semver prereleases, and ranges like `~5` don't match prereleases
2. **With `extract`**: Flux writes only the extracted version to the file

## Solution

Use prerelease-aware semver ranges (`~5.0.0-0`) instead of `extract`:
- The `-0` suffix makes semver match prerelease versions
- Pattern filter ensures only specific suffix (e.g., `-fpm-alpine`) is matched
- Full tag is written since no `extract` is configured

## Changes

* Use `~1.0.0-0` and `~5.0.0-0` ranges to match prerelease-style tags
* Remove `extract` field from matomo containers
* Fix helm chart to only output `extract` when configured
* Remove obsolete Bitnami HelmRepository