### PR TITLE
fix(matomo): use caret range for semver to allow minor version updates

### DIFF
--- a/k8s/matomo/helmrelease.yaml
+++ b/k8s/matomo/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           policy:
             type: semver
             pattern: '^\d+\.\d+\.\d+-alpine$'
-            range: "~1.0.0-0"
+            range: "^1.0.0-0"
         volumeMounts:
           - name: data
             mountPath: /var/www/html
@@ -36,13 +36,13 @@ spec:
       - name: php-fpm
         image:
           repository: matomo
-          tag: "5.0.3-fpm-alpine" # {"$imagepolicy": "nde:matomo-php-fpm:tag"}
+          tag: "5.6.2-fpm-alpine" # {"$imagepolicy": "nde:matomo-php-fpm:tag"}
         port: 9000
         flux:
           policy:
             type: semver
             pattern: '^\d+\.\d+\.\d+-fpm-alpine$'
-            range: "~5.0.0-0"
+            range: "^5.0.0-0"
         env:
           - name: MATOMO_DATABASE_HOST
             value: matomo-mariadb


### PR DESCRIPTION
## Summary

Fixes semver range to allow minor version updates. The previous `~5.0.0-0` range only allowed patch updates within 5.0.x, causing Matomo to downgrade from 5.6.2 to 5.0.3.

## Problem

- `~5.0.0-0` means `>=5.0.0-0 <5.1.0` - only matches 5.0.x
- `5.6.2-fpm-alpine` doesn't match this range
- Flux selected `5.0.3-fpm-alpine` as the "latest" within the allowed range

## Solution

- `^5.0.0-0` means `>=5.0.0-0 <6.0.0` - matches all 5.x versions
- Same fix applied to nginx range

## Changes

* Change `~5.0.0-0` → `^5.0.0-0` for matomo
* Change `~1.0.0-0` → `^1.0.0-0` for nginx  
* Restore matomo tag to `5.6.2-fpm-alpine`