### PR TITLE
Revert PR #130: fix(matomo) semver ranges

### DIFF
--- a/helm/nde-app/templates/flux-image-policy.yaml
+++ b/helm/nde-app/templates/flux-image-policy.yaml
@@ -22,12 +22,10 @@ spec:
     numerical:
       order: {{ (((.flux).policy).order) | default "asc" }}
   {{- else if eq $policyType "semver" }}
-  {{- if (((.flux).policy).pattern) }}
+  {{- if or (((.flux).policy).pattern) (((.flux).policy).extract) }}
   filterTags:
     pattern: {{ (((.flux).policy).pattern) | squote }}
-    {{- if (((.flux).policy).extract) }}
     extract: {{ (((.flux).policy).extract) | squote }}
-    {{- end }}
   {{- end }}
   policy:
     semver:

--- a/k8s/matomo/helmrelease.yaml
+++ b/k8s/matomo/helmrelease.yaml
@@ -25,8 +25,9 @@ spec:
         flux:
           policy:
             type: semver
-            pattern: '^\d+\.\d+\.\d+-alpine$'
-            range: "~1.0.0-0"
+            pattern: '^(?P<version>\d+\.\d+\.\d+)-alpine$'
+            extract: '$version'
+            range: "~1"
         volumeMounts:
           - name: data
             mountPath: /var/www/html
@@ -41,8 +42,9 @@ spec:
         flux:
           policy:
             type: semver
-            pattern: '^\d+\.\d+\.\d+-fpm-alpine$'
-            range: "~5.0.0-0"
+            pattern: '^(?P<version>\d+\.\d+\.\d+)-fpm-alpine$'
+            extract: '$version'
+            range: "~5"
         env:
           - name: MATOMO_DATABASE_HOST
             value: matomo-mariadb

--- a/k8s/matomo/helmrepository.yaml
+++ b/k8s/matomo/helmrepository.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: bitnami
+  namespace: nde
+spec:
+  type: oci
+  interval: 24h
+  url: oci://registry-1.docker.io/bitnamicharts


### PR DESCRIPTION
## Summary

Reverts #130 which broke matomo by changing semver ranges from `~5` to `~5.0.0-0`.

## What went wrong

- `~5.0.0-0` only matches 5.0.x versions (tilde = patch updates only)
- Flux downgraded matomo from 5.6.2 to 5.0.3
- The original `~5` range with `extract` was working correctly

## What this restores

PR #129's working config:
```yaml
pattern: '^(?P<version>\d+\.\d+\.\d+)-fpm-alpine$'
extract: '$version'
range: "~5"
```