### PR TITLE
fix(matomo): reorder nginx location blocks for static assets

### DIFF
--- a/k8s/matomo/helmrelease.yaml
+++ b/k8s/matomo/helmrelease.yaml
@@ -88,6 +88,12 @@ spec:
                 add_header X-Content-Type-Options "nosniff" always;
                 add_header X-XSS-Protection "1; mode=block" always;
 
+                # Static assets with caching (must come before deny blocks)
+                location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|json)$ {
+                    expires 1y;
+                    add_header Cache-Control "public, immutable";
+                }
+
                 # Deny access to sensitive directories
                 location ~ ^/(config|tmp|core|lang) {
                     deny all;
@@ -119,11 +125,6 @@ spec:
                 location ~* ^.+\.php$ {
                     deny all;
                     return 404;
-                }
-
-                location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
-                    expires 1y;
-                    add_header Cache-Control "public, immutable";
                 }
             }
     ingresses:


### PR DESCRIPTION
## Summary

Fixes 404 errors on static assets (logo, fonts, favicon, etc.) on matomo.netwerkdigitaalerfgoed.nl

## Problem

Static assets from `/plugins/` returning 404:
- `/plugins/Morpheus/images/logo.svg`
- `/plugins/Morpheus/fonts/matomo.woff2`
- `/plugins/CoreHome/images/favicon.png`

## Root Cause

Wrong nginx location block order. Per [official matomo-nginx config](https://github.com/matomo-org/matomo-nginx):
- Static assets block must come BEFORE deny blocks
- First matching regex wins in nginx

## Solution

Reorder location blocks to match official config:
1. Static assets (serves .js, .css, .png, .svg, .woff2, etc.)
2. Deny `/plugins/` and other sensitive directories