### PR TITLE
ci(deploy): only run when k8s-do changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'k8s-do/**'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

* Add path filter to deploy workflow so it only triggers when files in `k8s-do/` are changed
* Reduces unnecessary workflow runs for changes to other directories