### PR TITLE
feat(helm): add CNAME DNS record support

### DIFF
--- a/helm/nde-app/README.md
+++ b/helm/nde-app/README.md
@@ -8,6 +8,7 @@ Generic Helm chart for deploying NDE applications. It supports:
 - Persistent volumes
 - ConfigMaps
 - CronJobs
+- CNAME DNS records
 
 ## Flux Image Automation
 
@@ -41,3 +42,15 @@ containers:
         type: semver
         range: "~10.11"  # Only patch updates
 ```
+
+## CNAME DNS Records
+
+Create CNAME records via ExternalDNS without deploying any application:
+
+```yaml
+cnames:
+  - hostname: alias.netwerkdigitaalerfgoed.nl
+    target: target.example.com
+```
+
+This creates a Service of type `ExternalName` with the appropriate ExternalDNS annotation.

--- a/helm/nde-app/templates/cname.yaml
+++ b/helm/nde-app/templates/cname.yaml
@@ -1,0 +1,15 @@
+{{- range $index, $cname := .Values.cnames }}
+{{- $name := printf "%s-cname-%d" (include "nde-app.fullname" $) $index }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "nde-app.labels" $ | nindent 4 }}
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: {{ $cname.hostname }}
+spec:
+  type: ExternalName
+  externalName: {{ $cname.target }}
+{{- end }}

--- a/helm/nde-app/values.yaml
+++ b/helm/nde-app/values.yaml
@@ -111,3 +111,8 @@ cronjobs: []
   #   args: []
   #   env: []
   #   restartPolicy: OnFailure  # Optional, defaults to OnFailure
+
+# CNAME DNS records (via ExternalDNS)
+cnames: []
+  # - hostname: alias.example.com
+  #   target: target.example.com

--- a/k8s/status/helmrelease.yaml
+++ b/k8s/status/helmrelease.yaml
@@ -1,0 +1,19 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: status
+  namespace: nde
+spec:
+  serviceAccountName: nde
+  interval: 30m
+  chart:
+    spec:
+      chart: helm/nde-app
+      reconcileStrategy: Revision
+      sourceRef:
+        kind: GitRepository
+        name: nde
+  values:
+    cnames:
+      - hostname: status.netwerkdigitaalerfgoed.nl
+        target: stats.uptimerobot.com


### PR DESCRIPTION
## Summary

* Add `cnames` configuration option to nde-app Helm chart for creating CNAME DNS records via ExternalDNS
* Uses Kubernetes ExternalName Service with `external-dns.alpha.kubernetes.io/hostname` annotation
* Add status page CNAME: `status.netwerkdigitaalerfgoed.nl` → `stats.uptimerobot.com`

## Usage

```yaml
cnames:
  - hostname: alias.example.com
    target: target.example.com
```