### PR TITLE
fix(helm): use Ingress for CNAME records

### DIFF
--- a/helm/nde-app/README.md
+++ b/helm/nde-app/README.md
@@ -53,4 +53,4 @@ cnames:
     target: target.example.com
 ```
 
-This creates a Service of type `ExternalName` with the appropriate ExternalDNS annotation.
+This creates an Ingress with `external-dns.alpha.kubernetes.io/target` annotation.

--- a/helm/nde-app/templates/cname.yaml
+++ b/helm/nde-app/templates/cname.yaml
@@ -1,15 +1,15 @@
 {{- range $index, $cname := .Values.cnames }}
 {{- $name := printf "%s-cname-%d" (include "nde-app.fullname" $) $index }}
 ---
-apiVersion: v1
-kind: Service
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
   name: {{ $name }}
   labels:
     {{- include "nde-app.labels" $ | nindent 4 }}
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: {{ $cname.hostname }}
+    external-dns.alpha.kubernetes.io/target: {{ $cname.target }}
 spec:
-  type: ExternalName
-  externalName: {{ $cname.target }}
+  rules:
+    - host: {{ $cname.hostname }}
 {{- end }}


### PR DESCRIPTION
## Summary

* Use Ingress with `external-dns.alpha.kubernetes.io/target` annotation instead of ExternalName Service
* Works with default ExternalDNS config (no `--source=service` flag needed)