### PR TITLE
feat(matomo): configure SMTP with Mailjet for email sending

### DIFF
--- a/k8s/matomo/helmrelease.yaml
+++ b/k8s/matomo/helmrelease.yaml
@@ -60,6 +60,29 @@ spec:
                 key: mariadb-password
           - name: MATOMO_DATABASE_DBNAME
             value: matomo
+          - name: MATOMO_MAIL_TRANSPORT
+            value: smtp
+          - name: MATOMO_MAIL_PORT
+            value: "587"
+          - name: MATOMO_MAIL_ENCRYPTION
+            value: tls
+          - name: MATOMO_MAIL_TYPE
+            value: Login
+          - name: MATOMO_MAIL_HOST
+            valueFrom:
+              secretKeyRef:
+                name: smtp
+                key: SMTP_HOST
+          - name: MATOMO_MAIL_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: smtp
+                key: SMTP_USERNAME
+          - name: MATOMO_MAIL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: smtp
+                key: SMTP_PASSWORD
         volumeMounts:
           - name: data
             mountPath: /var/www/html

--- a/k8s/secrets/smtp.yaml
+++ b/k8s/secrets/smtp.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: smtp
+    namespace: nde
+type: Opaque
+stringData:
+    SMTP_HOST: ENC[AES256_GCM,data:9NahLQGzn3dKnt6LV42tXIc=,iv:undVwIyFd8paU0gt4nriFfCFxcU9CnsQj0TKX/twh70=,tag:7efWKx1JqRyEtNoa7/V/cg==,type:str]
+    SMTP_USERNAME: ENC[AES256_GCM,data:9Qndoe5SqRZ3W8NS5E2GP0Zsmk7prGXbrlVaXk1XSEI=,iv:iYOD/4UV5PBvVdOveS7j68mDR7MmP45IrtrCw6RxGmU=,tag:U0smnqkpNgj+SiGykNigxg==,type:str]
+    SMTP_PASSWORD: ENC[AES256_GCM,data:2wIXBDNlg2wuQCe+a9XvUNNAhQ==,iv:HYdHtNTHyiWdllVV020ID2Pr4s/muh/7yMfzd5IIqhk=,tag:RRIjGTwpClL8btBmi7rLlw==,type:str]
+sops:
+    age:
+        - recipient: age1qnjmyern7zmm5wpsclrpexu327xuqalpcthuk32hj8xn5ssts96s5hhhu8
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOeVp3K1hDMGJVN1dUcHRn
+            RzhzTkkrTGNZZHY1MGNxaDNQOWhvRDNjMkVNCjJLakliWDZHS0huQU1xRk54T3lr
+            RXZnY2hrL2xwbUozWTFKTG5PUnNGemsKLS0tIC9vc01rZHprNlRQdURidnc4RXVr
+            bTYrR0RxSHdSNzc0QTBzZC9GeWJNSEEKtyHs6CLypm0ylxS4axMthgL4xH+2zli/
+            ZZDwKPLhsnkIYO1010vhfyxbrEQc/0UgdDJkf2D8tW7F70lljJSnuA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-01-08T15:56:26Z"
+    mac: ENC[AES256_GCM,data:DS7MVm2gWXq8yQv9AlAGEwyu34ZX0NaZqDLEbsQI30Z1yQYOcAI0ATH4mQJa4UK/DQwwzC8qJm4UblEYsbfrxZhLcRsMX7sO2UQCJdm7EhLtJwhcVYfcPWSAhglJrjaMtzwSnqpvkFw3NphxxYlviJ/FRr0civVScumteaG28Co=,iv:0stOtIbaDKgPViBSFxOpav8ELz54NCjP5miHoR4Iy4g=,tag:gh/FoEzREOiYcMBpgrjNzw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2


### PR DESCRIPTION
## Summary

* Add SMTP configuration to Matomo for sending invitation and notification emails
* Use Mailjet as the email provider (EU-based, France)
* Create a reusable generic SMTP secret (`k8s/secrets/smtp.yaml`) with encrypted credentials

## Changes

* Add encrypted SMTP secret with Mailjet credentials
* Add SMTP environment variables to Matomo HelmRelease
* Use generic secret keys (SMTP_HOST, SMTP_USERNAME, SMTP_PASSWORD) for potential reuse by other apps

## Post-deployment

After Flux reconciles, enable the **EnvironmentVariables** plugin in Matomo:
- Go to Administration > System > Plugins
- Activate "EnvironmentVariables"

This is required for Matomo to read SMTP settings from environment variables.