### PR TITLE
fix(matomo): switch SMTP provider from Mailjet to Lettermint

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,5 +91,6 @@ See [k8s/secrets/README.md](k8s/secrets/README.md) for encryption instructions.
 
 ## Additional services
 
-UptimeRobot monitors our services. The status page can be found at https://status.netwerkdigitaalerfgoed.nl.
-To configure the status page, log in at the [dashboard](https://dashboard.uptimerobot.com).
+* UptimeRobot monitors our services. The status page can be found at https://status.netwerkdigitaalerfgoed.nl.
+  To configure the status page, log in at the [dashboard](https://dashboard.uptimerobot.com).
+* Lettermint.co sends our transactional e-mail.

--- a/k8s/secrets/smtp.yaml
+++ b/k8s/secrets/smtp.yaml
@@ -5,21 +5,21 @@ metadata:
     namespace: nde
 type: Opaque
 stringData:
-    SMTP_HOST: ENC[AES256_GCM,data:9NahLQGzn3dKnt6LV42tXIc=,iv:undVwIyFd8paU0gt4nriFfCFxcU9CnsQj0TKX/twh70=,tag:7efWKx1JqRyEtNoa7/V/cg==,type:str]
-    SMTP_USERNAME: ENC[AES256_GCM,data:9Qndoe5SqRZ3W8NS5E2GP0Zsmk7prGXbrlVaXk1XSEI=,iv:iYOD/4UV5PBvVdOveS7j68mDR7MmP45IrtrCw6RxGmU=,tag:U0smnqkpNgj+SiGykNigxg==,type:str]
-    SMTP_PASSWORD: ENC[AES256_GCM,data:2wIXBDNlg2wuQCe+a9XvUNNAhQ==,iv:HYdHtNTHyiWdllVV020ID2Pr4s/muh/7yMfzd5IIqhk=,tag:RRIjGTwpClL8btBmi7rLlw==,type:str]
+    SMTP_HOST: ENC[AES256_GCM,data:/H4Bhr3B2BtbEbiYYw4G2LR7,iv:LdLL6A5fAUoyObZYCamcz88Ta8uBWxI5Nr+a/0bkjuo=,tag:IEB/F/pCRMOuI5+YF0sWvQ==,type:str]
+    SMTP_USERNAME: ENC[AES256_GCM,data:zRVmT+qvJz8oYQ==,iv:CKEnhMfj5xesNV+Z7cmYx8zCTtAYtiq+1/X6usOPjCg=,tag:phhD6LqoXpvQ7UvF/GupHQ==,type:str]
+    SMTP_PASSWORD: ENC[AES256_GCM,data:Uo5MY7eYQO2lYFKHygkG+RhjmN8xixBeWoJ/JR+nDavS2xg=,iv:Olb6hk+rh9Yh42qlnneQcoL3CBmA/DMLSiy4Xuf6HvY=,tag:yybE83BPsJ0/bNdoaay3eQ==,type:str]
 sops:
     age:
         - recipient: age1qnjmyern7zmm5wpsclrpexu327xuqalpcthuk32hj8xn5ssts96s5hhhu8
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOeVp3K1hDMGJVN1dUcHRn
-            RzhzTkkrTGNZZHY1MGNxaDNQOWhvRDNjMkVNCjJLakliWDZHS0huQU1xRk54T3lr
-            RXZnY2hrL2xwbUozWTFKTG5PUnNGemsKLS0tIC9vc01rZHprNlRQdURidnc4RXVr
-            bTYrR0RxSHdSNzc0QTBzZC9GeWJNSEEKtyHs6CLypm0ylxS4axMthgL4xH+2zli/
-            ZZDwKPLhsnkIYO1010vhfyxbrEQc/0UgdDJkf2D8tW7F70lljJSnuA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0SkN2NUpJa3hxaTFTUlZP
+            Sndsc2dtbEFyVXhxZk00UnlVY0I0VjNpalU4CmhYMEpFL3d2Z0lQMFYyVXdMNFp0
+            SlU3dW12VjFuSEQ2VEZ0a3UySVBCK28KLS0tIE9GZ1Bxam56NjNieUY4WFlEVUFE
+            ZGYyc1kzTlB3SG1CaEw3U3ROeWpWc2cK54sB4A5kvw8eX8OwNFY/cWR3njzrCvqt
+            G1dpJ85Z8VBCrWq6x4X2olN77DOR8PcZ3qXqvFzUQBqXEYBnGJF04w==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-01-08T15:56:26Z"
-    mac: ENC[AES256_GCM,data:DS7MVm2gWXq8yQv9AlAGEwyu34ZX0NaZqDLEbsQI30Z1yQYOcAI0ATH4mQJa4UK/DQwwzC8qJm4UblEYsbfrxZhLcRsMX7sO2UQCJdm7EhLtJwhcVYfcPWSAhglJrjaMtzwSnqpvkFw3NphxxYlviJ/FRr0civVScumteaG28Co=,iv:0stOtIbaDKgPViBSFxOpav8ELz54NCjP5miHoR4Iy4g=,tag:gh/FoEzREOiYcMBpgrjNzw==,type:str]
+    lastmodified: "2026-01-09T09:36:47Z"
+    mac: ENC[AES256_GCM,data:EXzkbcfd7V6G7RO9izwInuy82FjsQLdP/gXFWJSTxh4v2gpHp4DWTwnCm/Tdr3xafublhP7uaGallA7oTTtiER2ZtSKdURDYfDsMm8HXccbjPXLbrQI4V2ypmZh5VOVeCQDJPSmIQIR9ARvwx7c/7KrUq41dnm3byJF8aUxIE54=,iv:fq4nCPXclgalp1cjokFXNtMmRzkzOF5465LWM5AnAVw=,tag:L2X1cW32b6tQRivNSwY9lw==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.10.2


### PR DESCRIPTION
## Summary

Switch Matomo's SMTP provider from Mailjet to Lettermint.

## Why

* Lettermint is fully EU-based (European infrastructure and support)
* Better team/multi-user pricing for our needs
* GDPR-compliant transactional email service

## Changes

* Update encrypted SMTP secret with Lettermint credentials

## Post-deployment

Enable the **EnvironmentVariables** plugin in Matomo (if not already enabled):
- Go to Administration > System > Plugins
- Activate "EnvironmentVariables"