### PR TITLE
fix(matomo): configure sender email address for outgoing mail

### DIFF
--- a/k8s/matomo/helmrelease.yaml
+++ b/k8s/matomo/helmrelease.yaml
@@ -83,6 +83,8 @@ spec:
               secretKeyRef:
                 name: smtp
                 key: SMTP_PASSWORD
+          - name: MATOMO_GENERAL_NOREPLY_EMAIL_ADDRESS
+            value: noreply@netwerkdigitaalerfgoed.nl
         volumeMounts:
           - name: data
             mountPath: /var/www/html


### PR DESCRIPTION
## Summary
* Add `MATOMO_GENERAL_NOREPLY_EMAIL_ADDRESS` environment variable to set the sender address for outgoing emails
* Uses `noreply@netwerkdigitaalerfgoed.nl` as the from address