### PR TITLE
feat(qlever): add rebuild-index sidecar for daily index rebuilds

### DIFF
--- a/k8s/dataset-register/qlever.yaml
+++ b/k8s/dataset-register/qlever.yaml
@@ -16,11 +16,14 @@ spec:
     workload:
       type: statefulset
 
+    shareProcessNamespace: true
+
     containers:
       - name: app
         image:
           repository: adfreiburg/qlever
-          tag: commit-688efa2
+          tag: REBUILD-INDEX-BETA
+          pullPolicy: Always
         flux:
           enabled: false
         port: 7001
@@ -62,9 +65,25 @@ spec:
           - -c
           - |
             cd /data
-            qlever index --overwrite-existing
-            qlever start --persist-updates --access-token "$ACCESS_TOKEN"
-            qlever log
+            INDEX_DIR=$(ls -d /data/rebuild.* 2>/dev/null | sort -r | head -1)
+
+            if [ -n "$INDEX_DIR" ]; then
+              echo "Starting from rebuild dir: $INDEX_DIR"
+              cd "$INDEX_DIR"
+            else
+              echo "No rebuild dir, building initial index..."
+              qlever index --overwrite-existing
+            fi
+
+            qlever start --access-token "$ACCESS_TOKEN"
+
+            # Log loop; restarts when sidecar kills qlever log after rebuild.
+            while true; do
+              INDEX_DIR=$(ls -d /data/rebuild.* 2>/dev/null | sort -r | head -1)
+              cd "${INDEX_DIR:-/data}"
+              echo "Tailing logs from $(pwd)"
+              qlever log || true
+            done
       - name: s3-sync
         image:
           repository: d3fk/s3cmd
@@ -98,6 +117,67 @@ spec:
                   put /data/dataset-register.update-triples s3://dataset-register/
               fi
               sleep 3600
+            done
+      - name: rebuild
+        image:
+          repository: adfreiburg/qlever
+          tag: REBUILD-INDEX-BETA
+          pullPolicy: Always
+        flux:
+          enabled: false
+        env:
+          - name: ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: dataset-register-qlever
+                key: access-token
+        volumeMounts:
+          - name: data
+            mountPath: /data
+          - name: config
+            mountPath: /data/Qleverfile
+            subPath: Qleverfile
+        command:
+          - sh
+          - -c
+          - |
+            while true; do
+              # Calculate seconds until 3 AM
+              now=$(date +%s)
+              today_3am=$(date -d "today 03:00" +%s 2>/dev/null || date -v3H -v0M -v0S +%s)
+              if [ $now -lt $today_3am ]; then
+                sleep_seconds=$((today_3am - now))
+              else
+                tomorrow_3am=$(date -d "tomorrow 03:00" +%s 2>/dev/null || date -v+1d -v3H -v0M -v0S +%s)
+                sleep_seconds=$((tomorrow_3am - now))
+              fi
+
+              echo "Sleeping until 3 AM ($sleep_seconds seconds)..."
+              sleep $sleep_seconds
+
+              echo "Starting index rebuild at $(date)"
+
+              # Find and cd to latest rebuild dir (to read that index), or /data if none
+              INDEX_DIR=$(ls -d /data/rebuild.* 2>/dev/null | sort -r | head -1)
+              cd "${INDEX_DIR:-/data}"
+
+              # Create new rebuild in /data (not nested)
+              NEW_DIR="/data/rebuild.$(date +%Y-%m-%dT%H:%M:%S)"
+              if ! qlever rebuild-index --access-token "$ACCESS_TOKEN" --index-dir "$NEW_DIR"; then
+                echo "ERROR: rebuild-index failed"
+                continue
+              fi
+            
+              cd "$NEW_DIR"
+              qlever start --access-token "$ACCESS_TOKEN" --kill-existing-with-same-port
+
+              # Signal app container to restart qlever log in new directory
+              pkill -f "qlever log" || true
+
+              # Cleanup rebuild directories older than 7 days
+              find /data -maxdepth 1 -name 'rebuild.*' -type d -mtime +7 -exec rm -rf {} \;
+
+              echo "Rebuild complete at $(date)"
             done
 
     securityContext:
@@ -143,6 +223,7 @@ spec:
             MEMORY_FOR_QUERIES = 5G
             CACHE_MAX_SIZE     = 2G
             TIMEOUT            = 30s
+            PERSIST_UPDATES    = true
 
             [runtime]
             SYSTEM = native


### PR DESCRIPTION
## Summary
* Add rebuild sidecar container that runs `qlever rebuild-index` daily at 3 AM to timestamped directories
* App container now checks for and starts from the latest rebuild directory on startup, enabling persistence across pod restarts
* Add log loop in app container that follows logs and restarts when sidecar signals directory switch via `pkill`
* Enable `shareProcessNamespace: true` for cross-container process signaling
* Cleanup rebuild directories older than 7 days to manage disk space
* Add `pullPolicy: Always` since REBUILD-INDEX-BETA is a moving Docker tag

## Test plan
- [ ] Verify pod starts and builds initial index when no rebuild directories exist
- [ ] Verify rebuild runs at 3 AM and creates timestamped directory
- [ ] Verify new server starts with `--kill-existing-with-same-port` after rebuild
- [ ] Verify logs continue streaming after rebuild completes
- [ ] Verify pod restart picks up latest rebuild directory
- [ ] Verify old rebuild directories are cleaned up after 7 days