### PR TITLE
fix(qlever): reduce startup probe delays for faster routing

### DIFF
--- a/k8s/dataset-register/qlever.yaml
+++ b/k8s/dataset-register/qlever.yaml
@@ -47,9 +47,9 @@ spec:
           httpGet:
             path: /?query=ASK%20%7B%7D
             port: 7001
-          initialDelaySeconds: 120
-          periodSeconds: 30
-          failureThreshold: 10  # Allow up to 7 minutes for indexing
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          failureThreshold: 60  # Allow time for indexing.
         livenessProbe:
           httpGet:
             path: /?query=ASK%20%7B%7D


### PR DESCRIPTION
## Summary
* Reduce startup probe delays to detect ready state faster and reduce downtime after restarts
* More frequent checks (10s vs 30s) while still allowing 10 min total for slow startups

## Changes
- `initialDelaySeconds`: 120s → 5s
- `periodSeconds`: 30s → 10s  
- `failureThreshold`: 10 → 60 (total time: ~10 min)

## Test plan
- [ ] Verify pod starts and becomes ready quickly when QLever is already indexed
- [ ] Verify slow startups (indexing) are still allowed to complete