### PR TITLE
ci(dataset-knowledge-graph): restore CronJob schedule

### DIFF
--- a/k8s/dataset-knowledge-graph/helmrelease.yaml
+++ b/k8s/dataset-knowledge-graph/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
         size: 500Gi
     cronjobs:
       - name: app
-        schedule: "7 14 * * *"
+        schedule: "15 1 * * *"
         concurrencyPolicy: Forbid
         backoffLimit: 1
         image: ghcr.io/netwerk-digitaal-erfgoed/dataset-knowledge-graph


### PR DESCRIPTION
Restore the dataset-knowledge-graph CronJob schedule from `7 14 * * *` (2:07 PM UTC, used for debugging) back to `15 1 * * *` (1:15 AM UTC).
