### PR TITLE
docs(software-requirements): clarify continuous container tagging

### DIFF
--- a/doc/software-requirements.md
+++ b/doc/software-requirements.md
@@ -31,9 +31,12 @@ The software service MUST be packaged as an [OCI](https://opencontainers.org) co
 
 See [CLARIAH #15](https://github.com/CLARIAH/clariah-plus/blob/main/requirements/software-requirements.md#15-services-must-be-packaged-as-containers).
 
-### 5. The container must be tagged with an incremental version number.
+### 5. The container must be periodically tagged with an incremental version number.
 
-The end of tech must either be a [semantic version increment](https://semver.org) or a simple timestamp-based increment
+The container MUST be re-tagged and released as a new Docker image periodically to reflect ongoing updates and
+maintenance (e.g. dependency upgrades, security patches, bug fixes).
+
+The tag must either be a [semantic version increment](https://semver.org) or a simple timestamp-based increment
 (`git show -s --format=%cd-%h --date=format:%Y%m%d%H%M%S`).
 
 See [CLARIAH #4](https://github.com/CLARIAH/clariah-plus/blob/main/requirements/software-requirements.md#4-the-software-must-be-released-periodically-with-clear-version-numbers).

--- a/doc/software-requirements.md
+++ b/doc/software-requirements.md
@@ -33,7 +33,7 @@ See [CLARIAH #15](https://github.com/CLARIAH/clariah-plus/blob/main/requirements
 
 ### 5. The container must be continuously tagged with an incremental version number.
 
-The container MUST be re-tagged and released as a new Docker image continuously to reflect ongoing updates and
+The container MUST be re-tagged and released as a new Docker image continuously to reflect updates and
 maintenance (e.g. dependency upgrades, security patches, bug fixes).
 
 The tag must either be a [semantic version increment](https://semver.org) or a simple timestamp-based increment

--- a/doc/software-requirements.md
+++ b/doc/software-requirements.md
@@ -31,9 +31,9 @@ The software service MUST be packaged as an [OCI](https://opencontainers.org) co
 
 See [CLARIAH #15](https://github.com/CLARIAH/clariah-plus/blob/main/requirements/software-requirements.md#15-services-must-be-packaged-as-containers).
 
-### 5. The container must be periodically tagged with an incremental version number.
+### 5. The container must be continuously tagged with an incremental version number.
 
-The container MUST be re-tagged and released as a new Docker image periodically to reflect ongoing updates and
+The container MUST be re-tagged and released as a new Docker image continuously to reflect ongoing updates and
 maintenance (e.g. dependency upgrades, security patches, bug fixes).
 
 The tag must either be a [semantic version increment](https://semver.org) or a simple timestamp-based increment


### PR DESCRIPTION
## Summary

Clarifies requirement 5 in `doc/software-requirements.md`:

- Fix garbled sentence (“The end of tech” → “The tag”).
- Update heading to state that containers must be **continuously** tagged with an incremental version number.
- Add a sentence explaining that containers must be re-tagged and released as new Docker images continuously to reflect updates and maintenance (dependency upgrades, security patches, bug fixes).
