### PR TITLE
feat(dataset-knowledge-graph): run nightly at 02:00 Amsterdam time

### DIFF
--- a/helm/nde-app/templates/cronjob.yaml
+++ b/helm/nde-app/templates/cronjob.yaml
@@ -8,6 +8,9 @@ metadata:
     {{- include "nde-app.labels" $ | nindent 4 }}
 spec:
   schedule: {{ required "cronjobs[].schedule is required" .schedule | quote }}
+  {{- with .timeZone }}
+  timeZone: {{ . | quote }}
+  {{- end }}
   {{- with .concurrencyPolicy }}
   concurrencyPolicy: {{ . }}
   {{- end }}

--- a/k8s/dataset-knowledge-graph/helmrelease.yaml
+++ b/k8s/dataset-knowledge-graph/helmrelease.yaml
@@ -18,7 +18,8 @@ spec:
         size: 500Gi
     cronjobs:
       - name: app
-        schedule: "7 14 * * *"
+        schedule: "0 2 * * *"
+        timeZone: Europe/Amsterdam
         concurrencyPolicy: Forbid
         backoffLimit: 1
         image: ghcr.io/netwerk-digitaal-erfgoed/dataset-knowledge-graph


### PR DESCRIPTION
## Summary

Reschedule the dataset-knowledge-graph (dkg) CronJob to run nightly at 02:00 Amsterdam time instead of 14:07 UTC.

## Changes

- **`k8s/dataset-knowledge-graph/helmrelease.yaml`**: change the schedule from `7 14 * * *` to `0 2 * * *` and add `timeZone: Europe/Amsterdam` so the job consistently runs at 02:00 Dutch local time year-round (handling DST).
- **`helm/nde-app/templates/cronjob.yaml`**: add support for an optional `timeZone` field on cronjobs. Without this, the `timeZone` value would have been silently dropped from the rendered CronJob.

Verified with `helm template` that the only changes to the rendered CronJob are the new `schedule` and `timeZone` fields.
