### PR TITLE
Trigger manual Geonames SPARQL reindex

### DIFF
--- a/k8s/geonames-sparql/reindex-job.yaml
+++ b/k8s/geonames-sparql/reindex-job.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: nde
   annotations:
     kustomize.toolkit.fluxcd.io/force: Enabled
-    reconcile.fluxcd.io/requestedAt: "2026-02-06"
+    reconcile.fluxcd.io/requestedAt: "2026-05-29T10:02:47Z"
 spec:
   template:
     spec:


### PR DESCRIPTION
Bumps the `reconcile.fluxcd.io/requestedAt` annotation on the `geonames-sparql-reindex-2` Job so Flux (with `kustomize.toolkit.fluxcd.io/force: Enabled`) deletes and recreates the immutable Job, kicking off a fresh manual reindex run to watch live in the Kubernetes dashboard.