### PR TITLE
Re-run Geonames SPARQL reindex as new Job

### DIFF
--- a/k8s/geonames-sparql/reindex-job.yaml
+++ b/k8s/geonames-sparql/reindex-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: geonames-sparql-reindex-2
+  name: geonames-sparql-reindex-3
   namespace: nde
   annotations:
     kustomize.toolkit.fluxcd.io/force: Enabled


### PR DESCRIPTION
Renames the manual reindex Job to `geonames-sparql-reindex-3`. A Job's pod template is immutable, so bumping an annotation on the existing Completed Job did not start a new run. Giving it a fresh name creates a brand-new Job and pod, which is the established re-run pattern (hence the `-2` / `-3` suffix).