### PR TITLE
Fix Geonames reindex Job OOMKill (give it 8Gi)

### DIFF
--- a/k8s/geonames-sparql/reindex-job.yaml
+++ b/k8s/geonames-sparql/reindex-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: geonames-sparql-reindex-3
+  name: geonames-sparql-reindex-4
   namespace: nde
   annotations:
     kustomize.toolkit.fluxcd.io/force: Enabled
@@ -23,6 +23,13 @@ spec:
       initContainers:
         - name: prepare-fuseki
           image: stain/jena-fuseki:5.1.0 # {"$imagepolicy": "nde:geonames-sparql-fuseki:tag"}
+          resources:
+            requests:
+              cpu: "1"
+              memory: 4Gi
+            limits:
+              cpu: "3"
+              memory: 8Gi
           volumeMounts:
             - name: data
               mountPath: /data
@@ -31,7 +38,7 @@ spec:
               mountPath: /fuseki-config
           env:
             - name: JVM_ARGS
-              value: "-Xmx3600M"
+              value: "-Xmx6G"
           command:
             - sh
             - -c


### PR DESCRIPTION
## Problem

The manual `geonames-sparql-reindex-3` Job died with `Init:OOMKilled` during the TDB load (right after `Start: geonames.ttl`), then went into CrashLoopBackOff. This is almost certainly what also killed the nightly run whose logs we couldn’t recover.

## Cause

Unlike the nightly CronJob (`indexer.yaml`), the manual reindex Job had **no `resources` block** on `prepare-fuseki`, so it ran under the namespace’s small default memory limit. The memory-mapped TDB load blew past that limit and the kernel OOM-killed it.

## Fix

Give the reindex Job the same memory budget as the proven nightly CronJob — `requests 4Gi`, `limits 8Gi`, `-Xmx6G` — and re-run it as a fresh Job (`-4`, since Job pod templates are immutable).