### PR TITLE
Load GeoNames with tdb2.xloader via jena-tools image (fixes OOM/slow index)

### DIFF
--- a/k8s/geonames-sparql/indexer.yaml
+++ b/k8s/geonames-sparql/indexer.yaml
@@ -26,11 +26,11 @@ spec:
           serviceAccountName: statefulset-manager
           initContainers:
             - name: prepare-fuseki
-              # stain/jena-fuseki only provides a JRE + curl/unzip/tar; it ships neither
-              # the TDB2 tools nor (per netwerkdigitaalerfgoed/fuseki) the Jena CLI tools.
-              # So we fetch the matching Apache Jena tools at runtime and load with
-              # tdb2.xloader (external-sort, memory-frugal) instead of the TDB1 tdbloader2.
-              image: stain/jena-fuseki:5.1.0
+              # Jena CLI tools image (tdb2.xloader, jena.textindexer on PATH), pinned to
+              # the SAME Jena version as the Fuseki server: the geonames-sparql-fuseki
+              # ImagePolicy resolves the tag and jena-tools is published in lockstep with
+              # fuseki (identical tags), so the loader and server never drift.
+              image: netwerkdigitaalerfgoed/jena-tools:6.1.0 # {"$imagepolicy": "nde:geonames-sparql-fuseki:tag"}
               resources:
                 requests:
                   cpu: "1"
@@ -56,7 +56,6 @@ spec:
                 - -c
                 - |
                   set -e
-                  JENA_VERSION=6.1.0
                   rm -rf /data/*
                   # Do all bulk work (download, unzipped TTL, xloader temp files) on the
                   # node-local scratch emptyDir, so the 50Gi data PVC only has to hold the
@@ -64,14 +63,9 @@ spec:
                   cd /scratch
                   curl -sS -O https://geonames.ams3.digitaloceanspaces.com/geonames.zip
                   unzip geonames.zip
-                  # The Fuseki image ships only the server, not the Jena CLI tools, so fetch
-                  # the matching Apache Jena tools (tdb2.xloader, jena.textindexer) at runtime.
-                  curl -sSL -O "https://repo1.maven.org/maven2/org/apache/jena/apache-jena/${JENA_VERSION}/apache-jena-${JENA_VERSION}.tar.gz"
-                  tar xzf "apache-jena-${JENA_VERSION}.tar.gz"
-                  export JENA_HOME="/scratch/apache-jena-${JENA_VERSION}"
-                  export PATH="$JENA_HOME/bin:$PATH"
                   # tdb2.xloader: external-sort bulk loader for large datasets on bounded
                   # memory. Builds a fresh TDB2 store; --tmpdir holds the large sort files.
+                  # tdb2.xloader and jena.textindexer are on PATH from the jena-tools image.
                   mkdir -p /scratch/tmp
                   tdb2.xloader --loc /data/tdb --tmpdir /scratch/tmp /scratch/geonames.ttl
                   echo "Creating Lucene index..."

--- a/k8s/geonames-sparql/indexer.yaml
+++ b/k8s/geonames-sparql/indexer.yaml
@@ -26,8 +26,10 @@ spec:
           serviceAccountName: statefulset-manager
           initContainers:
             - name: prepare-fuseki
-              # Pinned: indexer still uses tdbloader2 (TDB1-era loader bundled in stain/jena-fuseki).
-              # Migrate to netwerkdigitaalerfgoed/fuseki + tdb2.xloader in a separate PR.
+              # stain/jena-fuseki only provides a JRE + curl/unzip/tar; it ships neither
+              # the TDB2 tools nor (per netwerkdigitaalerfgoed/fuseki) the Jena CLI tools.
+              # So we fetch the matching Apache Jena tools at runtime and load with
+              # tdb2.xloader (external-sort, memory-frugal) instead of the TDB1 tdbloader2.
               image: stain/jena-fuseki:5.1.0
               resources:
                 requests:
@@ -42,20 +44,38 @@ spec:
                   subPath: staging
                 - name: fuseki-config
                   mountPath: /fuseki-config
+                - name: scratch
+                  mountPath: /scratch
               env:
+                # xloader uses external sort (which wants OS memory + page cache), not a
+                # large JVM heap, so keep the heap modest and leave room for sort(1).
                 - name: JVM_ARGS
-                  value: "-Xmx6G"
+                  value: "-Xmx4G"
               command:
                 - sh
                 - -c
                 - |
+                  set -e
+                  JENA_VERSION=6.1.0
                   rm -rf /data/*
+                  # Do all bulk work (download, unzipped TTL, xloader temp files) on the
+                  # node-local scratch emptyDir, so the 50Gi data PVC only has to hold the
+                  # live production index plus the freshly built staging index.
+                  cd /scratch
                   curl -sS -O https://geonames.ams3.digitaloceanspaces.com/geonames.zip
                   unzip geonames.zip
-                  ./tdbloader2 --loc=/data/tdb geonames.ttl
-                  rm -f /data/tdb/tdb.lock
+                  # The Fuseki image ships only the server, not the Jena CLI tools, so fetch
+                  # the matching Apache Jena tools (tdb2.xloader, jena.textindexer) at runtime.
+                  curl -sSL -O "https://repo1.maven.org/maven2/org/apache/jena/apache-jena/${JENA_VERSION}/apache-jena-${JENA_VERSION}.tar.gz"
+                  tar xzf "apache-jena-${JENA_VERSION}.tar.gz"
+                  export JENA_HOME="/scratch/apache-jena-${JENA_VERSION}"
+                  export PATH="$JENA_HOME/bin:$PATH"
+                  # tdb2.xloader: external-sort bulk loader for large datasets on bounded
+                  # memory. Builds a fresh TDB2 store; --tmpdir holds the large sort files.
+                  mkdir -p /scratch/tmp
+                  tdb2.xloader --loc /data/tdb --tmpdir /scratch/tmp /scratch/geonames.ttl
                   echo "Creating Lucene index..."
-                  java $JVM_ARGS -cp $FUSEKI_HOME/fuseki-server.jar jena.textindexer --desc=/fuseki-config/config.ttl
+                  jena.textindexer --desc=/fuseki-config/config.ttl
                   chmod -R g+w /data/*
           containers:
             - name: restart-server
@@ -87,5 +107,10 @@ spec:
             - name: fuseki-config
               configMap:
                 name: geonames-sparql-fuseki-config
+            # Node-local scratch for download + unzipped TTL + xloader sort files.
+            # sizeLimit bounds it so an overflow evicts only this pod, not the node.
+            - name: scratch
+              emptyDir:
+                sizeLimit: 40Gi
           securityContext:
             fsGroup: 100

--- a/k8s/geonames-sparql/reindex-job.yaml
+++ b/k8s/geonames-sparql/reindex-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: geonames-sparql-reindex-4
+  name: geonames-sparql-reindex-5
   namespace: nde
   annotations:
     kustomize.toolkit.fluxcd.io/force: Enabled
@@ -36,19 +36,38 @@ spec:
               subPath: staging
             - name: fuseki-config
               mountPath: /fuseki-config
+            - name: scratch
+              mountPath: /scratch
           env:
+            # xloader uses external sort (which wants OS memory + page cache), not a
+            # large JVM heap, so keep the heap modest and leave room for sort(1).
             - name: JVM_ARGS
-              value: "-Xmx6G"
+              value: "-Xmx4G"
           command:
             - sh
             - -c
             - |
+              set -e
+              JENA_VERSION=6.1.0
               rm -rf /data/*
+              # Do all bulk work (download, unzipped TTL, xloader temp files) on the
+              # node-local scratch emptyDir, so the 50Gi data PVC only has to hold the
+              # live production index plus the freshly built staging index.
+              cd /scratch
               curl -sS -O https://geonames.ams3.digitaloceanspaces.com/geonames.zip
               unzip geonames.zip
-              ./tdbloader2 --loc=/data/tdb geonames.ttl
+              # The Fuseki image ships only the server, not the Jena CLI tools, so fetch
+              # the matching Apache Jena tools (tdb2.xloader, jena.textindexer) at runtime.
+              curl -sSL -O "https://repo1.maven.org/maven2/org/apache/jena/apache-jena/${JENA_VERSION}/apache-jena-${JENA_VERSION}.tar.gz"
+              tar xzf "apache-jena-${JENA_VERSION}.tar.gz"
+              export JENA_HOME="/scratch/apache-jena-${JENA_VERSION}"
+              export PATH="$JENA_HOME/bin:$PATH"
+              # tdb2.xloader: external-sort bulk loader for large datasets on bounded
+              # memory. Builds a fresh TDB2 store; --tmpdir holds the large sort files.
+              mkdir -p /scratch/tmp
+              tdb2.xloader --loc /data/tdb --tmpdir /scratch/tmp /scratch/geonames.ttl
               echo "Creating Lucene index..."
-              java $JVM_ARGS -cp $FUSEKI_HOME/fuseki-server.jar jena.textindexer --desc=/fuseki-config/config.ttl
+              jena.textindexer --desc=/fuseki-config/config.ttl
               chmod -R g+w /data/*
       containers:
         - name: restart-server
@@ -73,5 +92,10 @@ spec:
         - name: fuseki-config
           configMap:
             name: geonames-sparql-fuseki-config
+        # Node-local scratch for download + unzipped TTL + xloader sort files.
+        # sizeLimit bounds it so an overflow evicts only this pod, not the node.
+        - name: scratch
+          emptyDir:
+            sizeLimit: 40Gi
       securityContext:
         fsGroup: 100

--- a/k8s/geonames-sparql/reindex-job.yaml
+++ b/k8s/geonames-sparql/reindex-job.yaml
@@ -22,7 +22,10 @@ spec:
       serviceAccountName: statefulset-manager
       initContainers:
         - name: prepare-fuseki
-          image: stain/jena-fuseki:5.1.0 # {"$imagepolicy": "nde:geonames-sparql-fuseki:tag"}
+          # Jena CLI tools image, pinned to the SAME Jena version as the Fuseki server:
+          # the geonames-sparql-fuseki ImagePolicy resolves the tag and jena-tools is
+          # published in lockstep with fuseki (identical tags), so they never drift.
+          image: netwerkdigitaalerfgoed/jena-tools:6.1.0 # {"$imagepolicy": "nde:geonames-sparql-fuseki:tag"}
           resources:
             requests:
               cpu: "1"
@@ -48,7 +51,6 @@ spec:
             - -c
             - |
               set -e
-              JENA_VERSION=6.1.0
               rm -rf /data/*
               # Do all bulk work (download, unzipped TTL, xloader temp files) on the
               # node-local scratch emptyDir, so the 50Gi data PVC only has to hold the
@@ -56,14 +58,9 @@ spec:
               cd /scratch
               curl -sS -O https://geonames.ams3.digitaloceanspaces.com/geonames.zip
               unzip geonames.zip
-              # The Fuseki image ships only the server, not the Jena CLI tools, so fetch
-              # the matching Apache Jena tools (tdb2.xloader, jena.textindexer) at runtime.
-              curl -sSL -O "https://repo1.maven.org/maven2/org/apache/jena/apache-jena/${JENA_VERSION}/apache-jena-${JENA_VERSION}.tar.gz"
-              tar xzf "apache-jena-${JENA_VERSION}.tar.gz"
-              export JENA_HOME="/scratch/apache-jena-${JENA_VERSION}"
-              export PATH="$JENA_HOME/bin:$PATH"
               # tdb2.xloader: external-sort bulk loader for large datasets on bounded
               # memory. Builds a fresh TDB2 store; --tmpdir holds the large sort files.
+              # tdb2.xloader and jena.textindexer are on PATH from the jena-tools image.
               mkdir -p /scratch/tmp
               tdb2.xloader --loc /data/tdb --tmpdir /scratch/tmp /scratch/geonames.ttl
               echo "Creating Lucene index..."


### PR DESCRIPTION
## What

Migrate GeoNames TDB loading from the TDB1-era `tdbloader2` to **`tdb2.xloader`** (the external-sort bulk loader built for large datasets on bounded memory), and run it from the new **`netwerkdigitaalerfgoed/jena-tools`** image instead of the unmaintained `stain/jena-fuseki`. Applies to both the nightly CronJob (`indexer.yaml`) and the manual reindex Job (`reindex-job.yaml`).

## Why

GeoNames has grown to **~137.7M triples**, and the old phased loader hits a memory cliff at the 8Gi container limit:

- `reindex-3` was **`Init:OOMKilled`** during the load.
- `reindex-4` cleared the load but the **index-build phase thrashed** (page-cache starvation from `-Xmx6G` leaving ~2Gi for the mmap’d index), eventually **saturating the node until its kubelet died** — evicting the reindex pod *and* taking the co-located live Fuseki endpoint down (~5–10 min outage).

`tdb2.xloader` uses external (on-disk) sort with sequential IO instead of a large mmap working set, so it stays within bounded memory and doesn’t OOM or thrash.

## How

- **Image:** `netwerkdigitaalerfgoed/jena-tools:6.1.0` (built by [`fuseki-docker#2`](https://github.com/netwerk-digitaal-erfgoed/fuseki-docker/pull/2)), which bakes the Jena CLI tools onto a GNU-coreutils base. No runtime tarball download. Pinned to the **same Jena version as the Fuseki server** via the shared `geonames-sparql-fuseki` ImagePolicy (jena-tools and fuseki publish identical tags), so loader and server never drift.
- **Scratch:** download, unzipped TTL and xloader `--tmpdir` go to a node-local `scratch` emptyDir (`sizeLimit: 40Gi`), so the **50Gi data PVC** only holds production + the freshly built staging index (~40GB), and an overflow **evicts just this pod, not the node** (directly mitigates the incident above). No PVC resize — the data PVC is a StatefulSet `volumeClaimTemplate`, which can’t be grown via GitOps.
- `-Xmx` lowered `6G → 4G` (xloader wants OS memory for `sort(1)`, not heap).
- Added `set -e` — the old script’s trailing `chmod` masked loader failures, so a failed load could proceed to the `staging → production` swap.
- `reindex-job` bumped to `-5`, so **merging this supersedes the running `-4` pod** (stops it and starts a clean xloader run).

## Validated locally

Ran the published image against the **full ~137.7M-triple** GeoNames dump, end to end, under an 8Gi limit:

- **arm64** (native): node table + indexes at **~670k triples/s**, no OOM, no thrash.
- **amd64** (cluster arch): `tdb2.xloader` + `jena.textindexer` complete cleanly; `sort` is GNU coreutils 9.4.

Testing also surfaced and fixed real landmines that would have shipped broken:
- xloader needs **`bash` + GNU `sort` + `jq`**. Both **Alpine** (busybox) and **plain `eclipse-temurin:21-jre`** (now Ubuntu 25.10 / `uutils-coreutils`) **corrupt the load** (`sort RC 141`, node-table `Bad hex char`). The image pins `eclipse-temurin:21-jre-noble` (Ubuntu 24.04 LTS, GNU coreutils) to avoid this.

## Depends on

- [`fuseki-docker#2`](https://github.com/netwerk-digitaal-erfgoed/fuseki-docker/pull/2) — **merged**, `jena-tools:6.1.0` **published**.

## Verify on first run

- [ ] The node has ≥40Gi ephemeral headroom for the `scratch` emptyDir.
- [ ] Load + index complete and the `staging → production` swap succeeds.
- [ ] The live endpoint stays up throughout (no node saturation, unlike the old loader).

## Not in scope (follow-ups)

- True build/serve separation (two PVCs / blue-green) so a rebuild can never share a node with the live server.
- De-duplicating the CronJob/reindex via a `kubectl create job --from=cronjob` trigger (needs ~4 lines of `create jobs` RBAC).
- Memory + GC logging in the init container for observability.
