### PR TITLE
Fix GeoNames reindex: build Lucene index in a 2nd init container (Fuseki image)

### DIFF
--- a/k8s/geonames-sparql/indexer.yaml
+++ b/k8s/geonames-sparql/indexer.yaml
@@ -34,7 +34,11 @@ spec:
               resources:
                 requests:
                   cpu: "1"
-                  memory: 4Gi
+                  # xloader is memory-frugal (external sort, modest heap), so a 2Gi
+                  # request is plenty for scheduling; the 8Gi limit covers the peak.
+                  # Lower request = less pressure on the nde namespace memory quota,
+                  # which matters because this runs at 02:00 alongside the dkg job.
+                  memory: 2Gi
                 limits:
                   cpu: "3"
                   memory: 8Gi

--- a/k8s/geonames-sparql/indexer.yaml
+++ b/k8s/geonames-sparql/indexer.yaml
@@ -25,11 +25,12 @@ spec:
                   topologyKey: kubernetes.io/hostname
           serviceAccountName: statefulset-manager
           initContainers:
-            - name: prepare-fuseki
-              # Jena CLI tools image (tdb2.xloader, jena.textindexer on PATH), pinned to
-              # the SAME Jena version as the Fuseki server: the geonames-sparql-fuseki
-              # ImagePolicy resolves the tag and jena-tools is published in lockstep with
-              # fuseki (identical tags), so the loader and server never drift.
+            # 1) Build the TDB2 store with tdb2.xloader. The jena-tools image carries the
+            #    Jena CLI tools on a GNU-coreutils base (xloader needs bash + GNU sort).
+            #    Pinned to the SAME Jena version as the Fuseki server via the shared
+            #    geonames-sparql-fuseki ImagePolicy (jena-tools and fuseki publish identical
+            #    tags), so loader and server never drift.
+            - name: prepare-tdb
               image: netwerkdigitaalerfgoed/jena-tools:6.1.0 # {"$imagepolicy": "nde:geonames-sparql-fuseki:tag"}
               resources:
                 requests:
@@ -46,8 +47,6 @@ spec:
                 - name: data
                   mountPath: /data
                   subPath: staging
-                - name: fuseki-config
-                  mountPath: /fuseki-config
                 - name: scratch
                   mountPath: /scratch
               env:
@@ -67,14 +66,41 @@ spec:
                   cd /scratch
                   curl -sS -O https://geonames.ams3.digitaloceanspaces.com/geonames.zip
                   unzip geonames.zip
-                  # tdb2.xloader: external-sort bulk loader for large datasets on bounded
-                  # memory. Builds a fresh TDB2 store; --tmpdir holds the large sort files.
-                  # tdb2.xloader and jena.textindexer are on PATH from the jena-tools image.
                   mkdir -p /scratch/tmp
                   tdb2.xloader --loc /data/tdb --tmpdir /scratch/tmp /scratch/geonames.ttl
+                  # Make the TDB2 store group-writable so the Fuseki server (group 100 via
+                  # fsGroup) can open it read-write after the swap. Done here because xloader
+                  # writes the files as root (this image's default user).
+                  chmod -R g+w /data
+            # 2) Build the Lucene text index. jena.textindexer ships only in the Fuseki
+            #    server jar (jena-text is not in the apache-jena CLI distribution), so run
+            #    it from the Fuseki image — Apache's documented method
+            #    (java -cp fuseki-server.jar jena.textindexer). Runs as the image's default
+            #    user (UID 1000) — the same UID as the server — so the index it writes is
+            #    already server-owned; no root needed.
+            - name: build-text-index
+              image: netwerkdigitaalerfgoed/fuseki:6.1.0 # {"$imagepolicy": "nde:geonames-sparql-fuseki:tag"}
+              resources:
+                requests:
+                  cpu: "1"
+                  memory: 2Gi
+                limits:
+                  cpu: "3"
+                  memory: 8Gi
+              volumeMounts:
+                - name: data
+                  mountPath: /data
+                  subPath: staging
+                - name: fuseki-config
+                  mountPath: /fuseki-config
+              command:
+                - sh
+                - -c
+                - |
+                  set -e
                   echo "Creating Lucene index..."
-                  jena.textindexer --desc=/fuseki-config/config.ttl
-                  chmod -R g+w /data/*
+                  jar=$(ls /fuseki/jena-fuseki-server-*.jar)
+                  "$JAVA_HOME/bin/java" -Xmx6g -cp "$jar" jena.textindexer --desc=/fuseki-config/config.ttl
           containers:
             - name: restart-server
               image: bitnami/kubectl:latest

--- a/k8s/geonames-sparql/reindex-job.yaml
+++ b/k8s/geonames-sparql/reindex-job.yaml
@@ -29,7 +29,10 @@ spec:
           resources:
             requests:
               cpu: "1"
-              memory: 4Gi
+              # xloader is memory-frugal (external sort, modest heap), so a 2Gi request
+              # is plenty for scheduling; the 8Gi limit covers the peak. Lower request =
+              # less pressure on the near-full nde namespace memory quota.
+              memory: 2Gi
             limits:
               cpu: "3"
               memory: 8Gi

--- a/k8s/geonames-sparql/reindex-job.yaml
+++ b/k8s/geonames-sparql/reindex-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: geonames-sparql-reindex-5
+  name: geonames-sparql-reindex-6
   namespace: nde
   annotations:
     kustomize.toolkit.fluxcd.io/force: Enabled
@@ -21,10 +21,12 @@ spec:
               topologyKey: kubernetes.io/hostname
       serviceAccountName: statefulset-manager
       initContainers:
-        - name: prepare-fuseki
-          # Jena CLI tools image, pinned to the SAME Jena version as the Fuseki server:
-          # the geonames-sparql-fuseki ImagePolicy resolves the tag and jena-tools is
-          # published in lockstep with fuseki (identical tags), so they never drift.
+        # 1) Build the TDB2 store with tdb2.xloader. The jena-tools image carries the
+        #    Jena CLI tools on a GNU-coreutils base (xloader needs bash + GNU sort).
+        #    Pinned to the SAME Jena version as the Fuseki server via the shared
+        #    geonames-sparql-fuseki ImagePolicy (jena-tools and fuseki publish identical
+        #    tags), so loader and server never drift.
+        - name: prepare-tdb
           image: netwerkdigitaalerfgoed/jena-tools:6.1.0 # {"$imagepolicy": "nde:geonames-sparql-fuseki:tag"}
           resources:
             requests:
@@ -40,8 +42,6 @@ spec:
             - name: data
               mountPath: /data
               subPath: staging
-            - name: fuseki-config
-              mountPath: /fuseki-config
             - name: scratch
               mountPath: /scratch
           env:
@@ -61,14 +61,41 @@ spec:
               cd /scratch
               curl -sS -O https://geonames.ams3.digitaloceanspaces.com/geonames.zip
               unzip geonames.zip
-              # tdb2.xloader: external-sort bulk loader for large datasets on bounded
-              # memory. Builds a fresh TDB2 store; --tmpdir holds the large sort files.
-              # tdb2.xloader and jena.textindexer are on PATH from the jena-tools image.
               mkdir -p /scratch/tmp
               tdb2.xloader --loc /data/tdb --tmpdir /scratch/tmp /scratch/geonames.ttl
+              # Make the TDB2 store group-writable so the Fuseki server (group 100 via
+              # fsGroup) can open it read-write after the swap. Done here because xloader
+              # writes the files as root (this image's default user).
+              chmod -R g+w /data
+        # 2) Build the Lucene text index. jena.textindexer ships only in the Fuseki
+        #    server jar (jena-text is not in the apache-jena CLI distribution), so run it
+        #    from the Fuseki image — Apache's documented method
+        #    (java -cp fuseki-server.jar jena.textindexer). Runs as the image's default
+        #    user (UID 1000) — the same UID as the server — so the index it writes is
+        #    already server-owned; no root needed.
+        - name: build-text-index
+          image: netwerkdigitaalerfgoed/fuseki:6.1.0 # {"$imagepolicy": "nde:geonames-sparql-fuseki:tag"}
+          resources:
+            requests:
+              cpu: "1"
+              memory: 2Gi
+            limits:
+              cpu: "3"
+              memory: 8Gi
+          volumeMounts:
+            - name: data
+              mountPath: /data
+              subPath: staging
+            - name: fuseki-config
+              mountPath: /fuseki-config
+          command:
+            - sh
+            - -c
+            - |
+              set -e
               echo "Creating Lucene index..."
-              jena.textindexer --desc=/fuseki-config/config.ttl
-              chmod -R g+w /data/*
+              jar=$(ls /fuseki/jena-fuseki-server-*.jar)
+              "$JAVA_HOME/bin/java" -Xmx6g -cp "$jar" jena.textindexer --desc=/fuseki-config/config.ttl
       containers:
         - name: restart-server
           image: bitnami/kubectl:latest


### PR DESCRIPTION
## What

Fix the GeoNames reindex so it actually builds the Lucene text index, by splitting the init into **two containers**, and lower the loader memory request. Bumps the manual reindex Job to `-6` (a fresh run with the fix).

## Why

`geonames-sparql-reindex-5` (from the merged #212) **failed** — `Job has reached the specified backoff limit`. Root cause: `jena.textindexer` is **not** in the `apache-jena` CLI distribution that the `jena-tools` image carries — `jena-text` + Lucene ship **only in the Fuseki server jar**. So the init flew through `tdb2.xloader`, then hit `jena.textindexer: command not found`, `set -e` failed it, and it retried to the backoff limit. (No outage/data loss — the live endpoint stayed on the previous index, and the node stayed healthy; xloader is gentle.)

## How

Two init containers, each tool in the image Apache intends for it:

1. **`prepare-tdb`** (`jena-tools`): `tdb2.xloader` → `/data/tdb`. Runs as **root** (the image default), so it also does one `chmod -R g+w /data` to make the TDB group-writable for the server.
2. **`build-text-index`** (`fuseki`): `java -cp jena-fuseki-server-*.jar jena.textindexer --desc=config.ttl` → `/data/index`. This is **Apache's documented method** for building a text index over an existing dataset. Runs as the Fuseki image's default **UID 1000 — the same UID as the server — so the index is already server-owned. No `runAsUser: 0`.**

Init containers run sequentially, so their 2Gi requests don't sum (no extra quota cost).

Also folds in: **right-size `requests.memory` 4Gi → 2Gi** (xloader/textindexer are frugal; the 8Gi limit covers the peak) to ease the ~96%-full `nde` memory quota.

## Validated locally (native arm64, full real pipeline on a slice)

- `tdb2.xloader` (jena-tools): 4.49M triples in **38s** → TDB built.
- `jena.textindexer` (fuseki jar): **12s, exit 0** → Lucene index built (`segments_1`). Extrapolates to ~5–7 min for the full 137.7M triples.
- Confirmed default users: `jena-tools` = `uid=0(root)`, `fuseki` = `uid=1000(fuseki)` — which is what the permissions design relies on.

## On merge

Flux prunes the failed `-5` and creates **`-6`**, running the corrected xloader → textindexer → swap. I'll watch it through all phases.

## Depends on

- `fuseki-docker#2` (merged) — `jena-tools:6.1.0` published. The Fuseki image was already deployed.
