### PR TITLE
Bound xloader sort buffer via /usr/bin/sort shadow (fixes reindex OOM kills)

### DIFF
--- a/k8s/geonames-sparql/indexer.yaml
+++ b/k8s/geonames-sparql/indexer.yaml
@@ -53,7 +53,7 @@ spec:
                 # xloader uses external sort (which wants OS memory + page cache), not a
                 # large JVM heap, so keep the heap modest and leave room for sort(1).
                 - name: JVM_ARGS
-                  value: "-Xmx4G"
+                  value: "-Xmx2G"
               command:
                 - sh
                 - -c
@@ -67,6 +67,15 @@ spec:
                   curl -sS -O https://geonames.ams3.digitaloceanspaces.com/geonames.zip
                   unzip geonames.zip
                   mkdir -p /scratch/tmp
+                  # tdb2.xloader hard-codes GNU sort --buffer-size=50% — of the HOST's RAM,
+                  # not the cgroup limit (no config knob exists). On a big node that balloons
+                  # past the memory limit and the kubelet kills the pod. Shadow /usr/bin/sort
+                  # with a wrapper that appends -S 1G (GNU sort: last --buffer-size wins), so
+                  # it uses a fixed 1Gi buffer and spills to --tmpdir on disk. Validated: full
+                  # 137.7M-triple load completes in an 8Gi no-swap container.
+                  cp /usr/bin/sort /usr/bin/sort.real
+                  printf '#!/bin/sh\nexec /usr/bin/sort.real "$@" -S 1G\n' > /usr/bin/sort
+                  chmod +x /usr/bin/sort
                   tdb2.xloader --loc /data/tdb --tmpdir /scratch/tmp /scratch/geonames.ttl
                   # Make the TDB2 store group-writable so the Fuseki server (group 100 via
                   # fsGroup) can open it read-write after the swap. Done here because xloader

--- a/k8s/geonames-sparql/reindex-job.yaml
+++ b/k8s/geonames-sparql/reindex-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: geonames-sparql-reindex-7
+  name: geonames-sparql-reindex-8
   namespace: nde
   annotations:
     kustomize.toolkit.fluxcd.io/force: Enabled
@@ -51,7 +51,7 @@ spec:
             # xloader uses external sort (which wants OS memory + page cache), not a
             # large JVM heap, so keep the heap modest and leave room for sort(1).
             - name: JVM_ARGS
-              value: "-Xmx4G"
+              value: "-Xmx2G"
           command:
             - sh
             - -c
@@ -69,6 +69,15 @@ spec:
               curl -sS -O https://geonames.ams3.digitaloceanspaces.com/geonames.zip || fail "download"
               unzip geonames.zip || fail "unzip"
               mkdir -p /scratch/tmp
+              # tdb2.xloader hard-codes GNU sort --buffer-size=50% — of the HOST's RAM,
+              # not the cgroup limit (no config knob exists). On a big node that balloons
+              # past the memory limit and the kubelet kills the pod. Shadow /usr/bin/sort
+              # with a wrapper that appends -S 1G (GNU sort: last --buffer-size wins), so
+              # it uses a fixed 1Gi buffer and spills to --tmpdir on disk. Validated: full
+              # 137.7M-triple load completes in an 8Gi no-swap container.
+              cp /usr/bin/sort /usr/bin/sort.real || fail "cp sort"
+              printf '#!/bin/sh\nexec /usr/bin/sort.real "$@" -S 1G\n' > /usr/bin/sort || fail "shadow sort"
+              chmod +x /usr/bin/sort || fail "chmod sort"
               tdb2.xloader --loc /data/tdb --tmpdir /scratch/tmp /scratch/geonames.ttl || fail "xloader"
               # Make the TDB2 store group-writable so the Fuseki server (group 100 via
               # fsGroup) can open it read-write after the swap. Done here because xloader


### PR DESCRIPTION
## Root cause (finally pinned, and validated)

Every reindex since the xloader migration (`-5`, `-6`, `-7`) died at the index-build phase, SIGKILL'd with no logs, and never reproduced locally. Cause:

> `tdb2.xloader` runs GNU `sort` with a **hard-coded `--buffer-size=50%`** — 50% of the **host node's** RAM, *not* the container's cgroup limit — and there's **no env/flag/property to change it** (confirmed on the [Jena dev list](https://www.mail-archive.com/dev@jena.apache.org/msg30990.html)).

On a big prod node, 50% of RAM dwarfs the 8Gi limit. K8s has **no swap**, so it can't spill — memory spikes, the node is pressured, and the kubelet **SIGTERM-kills the whole pod** (a `Killing`, not an `OOMKilled` — invisible, and it bypasses our `fail()` hold-on-failure). It never reproduced on my laptop because my laptop has far less RAM, so 50% there is small.

## Fix

Shadow `/usr/bin/sort` with a wrapper that appends **`-S 1G`** (GNU sort uses the *last* `--buffer-size`), forcing a fixed 1Gi buffer that spills to `--tmpdir` on disk:

```sh
cp /usr/bin/sort /usr/bin/sort.real
printf '#!/bin/sh\nexec /usr/bin/sort.real "$@" -S 1G\n' > /usr/bin/sort
chmod +x /usr/bin/sort
```

Jena invokes `sort` via `PATH`, so the shadow is reached (verified — the captured calls show `--buffer-size=50% … -S 1G`). Applied to `prepare-tdb` in both `reindex-job.yaml` (→ `-8`) and `indexer.yaml`; also `-Xmx 4G → 2G`.

## Validated end-to-end (this time for real)

Full **137,686,931-triple** load + Terms/SPO/POS/OSP index builds, in an **8Gi container with `--memory-swap=8g` (no swap, like K8s)**:

```
XLOADER EXIT=0
Overall  00h 23m 59s   |   95,682 tuples/sec
```

Zero `Sort RC=137`/Killed — where every prior run (and the unbounded sort) OOMed at the Terms sort.

Caveat: local can't reproduce the *unbounded* failure (laptop RAM), but it *can* and does prove the **bound takes effect** — the wrapper forces the same fixed 1Gi regardless of host RAM, which is exactly what caps the cluster's otherwise-huge buffer.

## On merge

Flux prunes `-7` and runs `-8`. The `hold-on-failure` safety net stays, and any genuine over-budget would now be a *clean* `OOMKilled`. This should let the reindex complete on the current 8Gi limit — independent of the pending SURF quota increase.

## Follow-up

Cleaner than patching `/usr/bin/sort` at runtime: bake the bounded-`sort` wrapper into the `jena-tools` image (`fuseki-docker`).
