### PR TITLE
fix(geonames-sparql): bound xloader sort + free node memory so the reindex lands

### DIFF
--- a/k8s/dataset-register/qlever.yaml
+++ b/k8s/dataset-register/qlever.yaml
@@ -35,12 +35,16 @@ spec:
                 key: access-token
         resources:
           # requests = limits for Guaranteed QoS.
+          # Right-sized from 12Gi: qlever serves on ~0.7Gi (memory-mapped, frugal),
+          # so 12Gi reserved ~11Gi of standing quota it never used. 4Gi keeps a
+          # ~5.7x headroom over steady serving while freeing 8Gi on the near-full
+          # nde quota. Revisit if a bulk re-import needs more (its only real peak).
           requests:
             cpu: "2"
-            memory: 12Gi
+            memory: 4Gi
           limits:
             cpu: "2"
-            memory: 12Gi
+            memory: 4Gi
         startupProbe:
           httpGet:
             path: /?query=ASK%20%7B%7D

--- a/k8s/geonames-sparql/indexer.yaml
+++ b/k8s/geonames-sparql/indexer.yaml
@@ -4,7 +4,11 @@ metadata:
   name: geonames-sparql-indexer
   namespace: nde
 spec:
-  schedule: "0 2 * * *"
+  # Staggered to 04:00 so it does not collide with the dataset-knowledge-graph
+  # CronJob (02:00) on the shared, near-full node. Two 12Gi-class jobs running at
+  # once caused node memory pressure that got the reindex pod killed; the 2h gap
+  # lets dkg finish (and release its memory) before the reindex starts.
+  schedule: "0 4 * * *"
   concurrencyPolicy: Replace
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 3

--- a/k8s/geonames-sparql/indexer.yaml
+++ b/k8s/geonames-sparql/indexer.yaml
@@ -53,7 +53,7 @@ spec:
                 # xloader uses external sort (which wants OS memory + page cache), not a
                 # large JVM heap, so keep the heap modest and leave room for sort(1).
                 - name: JVM_ARGS
-                  value: "-Xmx4G"
+                  value: "-Xmx2G"
               command:
                 - sh
                 - -c
@@ -67,6 +67,15 @@ spec:
                   curl -sS -O https://geonames.ams3.digitaloceanspaces.com/geonames.zip
                   unzip geonames.zip
                   mkdir -p /scratch/tmp
+                  # tdb2.xloader hard-codes GNU sort --buffer-size=50% — of the HOST's RAM,
+                  # not the cgroup limit (no config knob exists). On a big node that balloons
+                  # past the memory limit and the kubelet kills the pod. Shadow /usr/bin/sort
+                  # with a wrapper that appends -S 1G (GNU sort: last --buffer-size wins), so
+                  # it uses a fixed 1Gi buffer and spills to --tmpdir on disk. Validated: full
+                  # 137.7M-triple load completes in an 8Gi no-swap container.
+                  cp /usr/bin/sort /usr/bin/sort.real
+                  printf '#!/bin/sh\nexec /usr/bin/sort.real "$@" -S 1G\n' > /usr/bin/sort
+                  chmod +x /usr/bin/sort
                   tdb2.xloader --loc /data/tdb --tmpdir /scratch/tmp /scratch/geonames.ttl
                   # Make the TDB2 store group-writable so the Fuseki server (group 100 via
                   # fsGroup) can open it read-write after the swap. Done here because xloader

--- a/k8s/geonames-sparql/reindex-job.yaml
+++ b/k8s/geonames-sparql/reindex-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: geonames-sparql-reindex-7
+  name: geonames-sparql-reindex-8
   namespace: nde
   annotations:
     kustomize.toolkit.fluxcd.io/force: Enabled
@@ -51,7 +51,7 @@ spec:
             # xloader uses external sort (which wants OS memory + page cache), not a
             # large JVM heap, so keep the heap modest and leave room for sort(1).
             - name: JVM_ARGS
-              value: "-Xmx4G"
+              value: "-Xmx2G"
           command:
             - sh
             - -c
@@ -69,6 +69,15 @@ spec:
               curl -sS -O https://geonames.ams3.digitaloceanspaces.com/geonames.zip || fail "download"
               unzip geonames.zip || fail "unzip"
               mkdir -p /scratch/tmp
+              # tdb2.xloader hard-codes GNU sort --buffer-size=50% — of the HOST's RAM,
+              # not the cgroup limit (no config knob exists). On a big node that balloons
+              # past the memory limit and the kubelet kills the pod. Shadow /usr/bin/sort
+              # with a wrapper that appends -S 1G (GNU sort: last --buffer-size wins), so
+              # it uses a fixed 1Gi buffer and spills to --tmpdir on disk. Validated: full
+              # 137.7M-triple load completes in an 8Gi no-swap container.
+              cp /usr/bin/sort /usr/bin/sort.real || fail "cp sort"
+              printf '#!/bin/sh\nexec /usr/bin/sort.real "$@" -S 1G\n' > /usr/bin/sort || fail "shadow sort"
+              chmod +x /usr/bin/sort || fail "chmod sort"
               tdb2.xloader --loc /data/tdb --tmpdir /scratch/tmp /scratch/geonames.ttl || fail "xloader"
               # Make the TDB2 store group-writable so the Fuseki server (group 100 via
               # fsGroup) can open it read-write after the swap. Done here because xloader


### PR DESCRIPTION
## Why

The nightly GeoNames reindex (137.7M triples) kept getting killed on the cluster. Two root causes, addressed together here so the reindex can actually complete the staging → production swap:

1. **Unbounded sort buffer.** `tdb2.xloader` hard-codes GNU `sort --buffer-size=50%` – of the *host* RAM, not the cgroup limit (no config knob exists). On a big node that balloons past the container memory limit and the kubelet kills the pod.
2. **Node memory pressure.** The reindex shared a near-full node with other 12Gi-class workloads, so even a well-behaved reindex pod got node-OOM/evicted.

## What

- **Bound the xloader sort buffer** (`indexer.yaml`, `reindex-job.yaml`): shadow `/usr/bin/sort` with a wrapper that appends `-S 1G` (GNU sort: last `--buffer-size` wins), so it uses a fixed 1Gi buffer and spills to `--tmpdir` on disk. Validated locally: the full 137.7M-triple load completes in an 8Gi no-swap container. Also drops `JVM_ARGS` to `-Xmx2G` (xloader wants OS memory for external sort, not a big heap).
- **Stagger the nightly reindex to 04:00** (`indexer.yaml`): it no longer collides with the `dataset-knowledge-graph` CronJob at 02:00. The 2h gap lets dkg finish and release its memory before the reindex starts.
- **Right-size qlever memory 12Gi → 4Gi** (`qlever.yaml`): `dataset-register-qlever-0` serves on ~0.7Gi (memory-mapped, frugal), so 12Gi reserved ~11Gi of standing quota it never used. 4Gi keeps a ~5.7x headroom over steady serving while freeing 8Gi on the near-full nde quota, and stays Guaranteed QoS (request = limit). Revisit if a bulk re-import needs more – its only real memory peak.

## Notes

- Together the stagger + qlever right-size remove the node pressure; the bounded sort keeps the reindex itself within its limit.
- The `reindex-job.yaml` one-off Job manifest (`reindex-8`) is included for completeness; re-running the manual reindex after merge is a separate step (bump to a fresh Job name).
- qlever's resource change rolls `dataset-register-qlever-0`, so that SPARQL endpoint is briefly unavailable while it restarts.
