### PR TITLE
fix(dataset-register): restore qlever 12Gi limit for mmap page cache

### DIFF
--- a/k8s/dataset-register/qlever.yaml
+++ b/k8s/dataset-register/qlever.yaml
@@ -34,17 +34,19 @@ spec:
                 name: dataset-register-qlever
                 key: access-token
         resources:
-          # requests = limits for Guaranteed QoS.
-          # Right-sized from 12Gi: qlever serves on ~0.7Gi (memory-mapped, frugal),
-          # so 12Gi reserved ~11Gi of standing quota it never used. 4Gi keeps a
-          # ~5.7x headroom over steady serving while freeing 8Gi on the near-full
-          # nde quota. Revisit if a bulk re-import needs more (its only real peak).
+          # qlever is memory-mapped: the cgroup memory LIMIT bounds working set +
+          # mmap'd index page cache, NOT just RSS. Capping the limit too low starves
+          # the page cache and queries fault from disk (very slow) — the working-set
+          # metric stays ~0.7Gi and hides this. So keep the limit at 12Gi for caching
+          # headroom, but lower the request to 4Gi (~5.7x the ~0.7Gi working set) to
+          # free ~8Gi of standing request-quota on the near-full nde namespace.
+          # Burstable QoS as a result (request < limit).
           requests:
             cpu: "2"
             memory: 4Gi
           limits:
             cpu: "2"
-            memory: 4Gi
+            memory: 12Gi
         startupProbe:
           httpGet:
             path: /?query=ASK%20%7B%7D


### PR DESCRIPTION
## Why

Right-sizing qlever to `request = limit = 4Gi` (#216) made faceted-search queries **very slow**.

Root cause: qlever is **memory-mapped**. The cgroup memory *limit* bounds working set **+** mmap'd index page cache, not just RSS. Capping the limit at 4Gi starved the page cache, so queries fault index pages from disk on every request. The working-set metric stayed at ~0.7Gi and *hid* this – page cache is reclaimable and not counted in working set, so the pod looked idle while it was actually thrashing.

## What

Restore the **limit to 12Gi** so the page cache has room to keep the index hot, but **keep the request at 4Gi** (~5.7x the ~0.7Gi working set). Net effect:

- Query performance restored (page cache can grow back).
- Still frees ~8Gi of standing **request** quota on the near-full nde namespace – the request is what counts against scheduling room for the reindex.
- QoS becomes Burstable (request < limit), an acceptable trade now that the node has more headroom.

## Lesson

For memory-mapped stores (qlever, TDB2), size the **request** from the working set but keep the **limit** generous for page cache. Never right-size the limit of an mmap database by its working-set metric alone.
