### PR TITLE
chore(geonames-sparql): trigger manual reindex-9

### DIFF
--- a/k8s/geonames-sparql/reindex-job.yaml
+++ b/k8s/geonames-sparql/reindex-job.yaml
@@ -1,11 +1,11 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: geonames-sparql-reindex-8
+  name: geonames-sparql-reindex-9
   namespace: nde
   annotations:
     kustomize.toolkit.fluxcd.io/force: Enabled
-    reconcile.fluxcd.io/requestedAt: "2026-05-29T10:02:47Z"
+    reconcile.fluxcd.io/requestedAt: "2026-06-02T17:03:41Z"
 spec:
   # One attempt: on failure the init scripts hold the pod alive (sleep) so its logs
   # stay readable in the Dashboard — so we don't want the Job to retry/recreate.


### PR DESCRIPTION
Manual GeoNames reindex run to validate the bounded-sort fix end-to-end on the cluster, now that the dkg collision is removed (stagger) and ~8Gi of namespace quota is freed (qlever right-size).

Watching live. The reindex co-locates with Fuseki (RWO PVC), and Fuseki keeps serving (~9Gi) through the build, so node-level memory during the build is the remaining risk we cannot measure (no node read access). The bounded sort should keep the reindex's own footprint to ~3-4Gi.