### PR TITLE
fix(geonames-sparql): strip xloader sort --buffer-size so -S bounds it (reindex-10)

### DIFF
--- a/k8s/geonames-sparql/indexer.yaml
+++ b/k8s/geonames-sparql/indexer.yaml
@@ -71,14 +71,17 @@ spec:
                   curl -sS -O https://geonames.ams3.digitaloceanspaces.com/geonames.zip
                   unzip geonames.zip
                   mkdir -p /scratch/tmp
-                  # tdb2.xloader hard-codes GNU sort --buffer-size=50% — of the HOST's RAM,
-                  # not the cgroup limit (no config knob exists). On a big node that balloons
-                  # past the memory limit and the kubelet kills the pod. Shadow /usr/bin/sort
-                  # with a wrapper that appends -S 1G (GNU sort: last --buffer-size wins), so
-                  # it uses a fixed 1Gi buffer and spills to --tmpdir on disk. Validated: full
-                  # 137.7M-triple load completes in an 8Gi no-swap container.
+                  # tdb2.xloader’s sort calls hard-code GNU sort --buffer-size=50% – of the
+                  # HOST’s RAM, not the cgroup limit. The percentage is emitted by the Java
+                  # node-table and index builders, with no config knob. GNU sort uses the
+                  # LARGEST buffer size given, so appending -S does NOT override it; the
+                  # --buffer-size argument must be stripped. Shadow /usr/bin/sort with a
+                  # wrapper that removes any --buffer-size and forces -S 1G, so sort spills
+                  # to --tmpdir on disk and stays within the cgroup memory limit. Validated
+                  # on the amd64 image under a hard docker --memory cap (appending -S was a
+                  # no-op: GNU sort kept the larger 50% buffer and OOM-killed the pod).
                   cp /usr/bin/sort /usr/bin/sort.real
-                  printf '#!/bin/sh\nexec /usr/bin/sort.real "$@" -S 1G\n' > /usr/bin/sort
+                  printf '%s\n' '#!/bin/sh' 'set -f' 'n=""' 'for a in "$@"; do' '  case "$a" in --buffer-size=*) ;; *) n="$n $a" ;; esac' 'done' 'exec /usr/bin/sort.real $n -S 1G' > /usr/bin/sort
                   chmod +x /usr/bin/sort
                   tdb2.xloader --loc /data/tdb --tmpdir /scratch/tmp /scratch/geonames.ttl
                   # Make the TDB2 store group-writable so the Fuseki server (group 100 via

--- a/k8s/geonames-sparql/reindex-job.yaml
+++ b/k8s/geonames-sparql/reindex-job.yaml
@@ -1,11 +1,11 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: geonames-sparql-reindex-9
+  name: geonames-sparql-reindex-10
   namespace: nde
   annotations:
     kustomize.toolkit.fluxcd.io/force: Enabled
-    reconcile.fluxcd.io/requestedAt: "2026-06-02T17:03:41Z"
+    reconcile.fluxcd.io/requestedAt: "2026-06-02T18:34:58Z"
 spec:
   # One attempt: on failure the init scripts hold the pod alive (sleep) so its logs
   # stay readable in the Dashboard — so we don't want the Job to retry/recreate.
@@ -69,14 +69,17 @@ spec:
               curl -sS -O https://geonames.ams3.digitaloceanspaces.com/geonames.zip || fail "download"
               unzip geonames.zip || fail "unzip"
               mkdir -p /scratch/tmp
-              # tdb2.xloader hard-codes GNU sort --buffer-size=50% — of the HOST's RAM,
-              # not the cgroup limit (no config knob exists). On a big node that balloons
-              # past the memory limit and the kubelet kills the pod. Shadow /usr/bin/sort
-              # with a wrapper that appends -S 1G (GNU sort: last --buffer-size wins), so
-              # it uses a fixed 1Gi buffer and spills to --tmpdir on disk. Validated: full
-              # 137.7M-triple load completes in an 8Gi no-swap container.
+              # tdb2.xloader’s sort calls hard-code GNU sort --buffer-size=50% – of the
+              # HOST’s RAM, not the cgroup limit. The percentage is emitted by the Java
+              # node-table and index builders, with no config knob. GNU sort uses the
+              # LARGEST buffer size given, so appending -S does NOT override it; the
+              # --buffer-size argument must be stripped. Shadow /usr/bin/sort with a
+              # wrapper that removes any --buffer-size and forces -S 1G, so sort spills to
+              # --tmpdir on disk and stays within the cgroup memory limit. Validated on the
+              # amd64 image under a hard docker --memory cap (appending -S was a no-op:
+              # GNU sort kept the larger 50% buffer and OOM-killed the pod on big nodes).
               cp /usr/bin/sort /usr/bin/sort.real || fail "cp sort"
-              printf '#!/bin/sh\nexec /usr/bin/sort.real "$@" -S 1G\n' > /usr/bin/sort || fail "shadow sort"
+              printf '%s\n' '#!/bin/sh' 'set -f' 'n=""' 'for a in "$@"; do' '  case "$a" in --buffer-size=*) ;; *) n="$n $a" ;; esac' 'done' 'exec /usr/bin/sort.real $n -S 1G' > /usr/bin/sort || fail "shadow sort"
               chmod +x /usr/bin/sort || fail "chmod sort"
               tdb2.xloader --loc /data/tdb --tmpdir /scratch/tmp /scratch/geonames.ttl || fail "xloader"
               # Make the TDB2 store group-writable so the Fuseki server (group 100 via


### PR DESCRIPTION
## Why

`reindex-9` OOM-killed ~28 min into `prepare-tdb`, and root-cause analysis on the **exact amd64 image** (under a hard `docker --memory` cap) showed the previous sort fix was a **no-op**:

- `tdb2.xloader`’s sort calls hard-code `--buffer-size=50%` – of the **host** RAM, not the cgroup limit (the percentage is emitted by the Java node-table and index builders; no config knob).
- GNU sort uses the **largest** buffer size given, so the old wrapper that *appended* `-S 1G` never overrode the 50%. Reproduced: `--buffer-size=50% … -S 64M` is killed; `-S 64M` alone completes.
- The local “validation” passed only by luck – this dev VM is 12GB, so 50% = 6GB fit under the 8Gi cap. On the big cluster node, 50% is tens of GB ≫ 8Gi → OOM.

## What

Change the shadow `/usr/bin/sort` wrapper to **strip** any `--buffer-size=…` from the args and then force its own `-S 1G`, instead of appending. Validated on `netwerkdigitaalerfgoed/jena-tools:6.1.0` (amd64): sorting 30M lines with `--buffer-size=50%` present now completes under a 256m cap.

Applied to both the manual `reindex-job.yaml` (bumped to `reindex-10`) and the nightly `indexer.yaml` CronJob.

## Note

This addresses the reindex’s own memory footprint. Companion changes already merged: stagger to 04:00 (off the dkg collision) and qlever request right-size (freed quota). Re-running `reindex-10` watched live.
