### PR TITLE
fix(geonames-sparql): finish text-index swap + chmod for future runs

### DIFF
--- a/k8s/geonames-sparql/finish-swap-job.yaml
+++ b/k8s/geonames-sparql/finish-swap-job.yaml
@@ -1,0 +1,54 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  # One-off: reindex-10 loaded the 137.7M-triple TDB store into production, but the
+  # restart-server step failed to move the Lucene text index (mv: Permission denied —
+  # renaming a directory needs write on the directory itself, and build-text-index
+  # created /data/staging/index as UID 1000 mode 755, which the group-100 restart-server
+  # container could not move). The text index was built successfully and still sits in
+  # /data/staging/index, so this job finishes the swap (move it into production) as root,
+  # without redoing the ~48m load. The permanent fix (chmod in build-text-index) lands in
+  # reindex-job.yaml / indexer.yaml. Prune this Job via GitOps once it has completed.
+  name: geonames-sparql-finish-swap
+  namespace: nde
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: Enabled
+    reconcile.fluxcd.io/requestedAt: "2026-06-03T18:01:41Z"
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      serviceAccountName: statefulset-manager
+      # Run as root so it can move the UID-1000-owned text index directory.
+      securityContext:
+        runAsUser: 0
+        fsGroup: 100
+      containers:
+        - name: finish-swap
+          image: bitnami/kubectl:latest
+          volumeMounts:
+            # Mount the whole PVC (no subPath) so both staging and production are visible.
+            - name: data
+              mountPath: /data
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              if [ ! -d /data/staging/index ]; then
+                echo "### /data/staging/index missing — nothing to finish; aborting ###"
+                exit 1
+              fi
+              echo "Found staging text index; scaling Fuseki down for the swap"
+              kubectl scale statefulset/geonames-sparql --replicas=0
+              kubectl rollout status statefulset/geonames-sparql --watch
+              rm -rf /data/production/index
+              mv /data/staging/index /data/production/index
+              # Group-writable so a future server (group 100 via fsGroup) can open it.
+              chmod -R g+w /data/production/index
+              kubectl scale statefulset/geonames-sparql --replicas=1
+      restartPolicy: OnFailure
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: data-geonames-sparql-0

--- a/k8s/geonames-sparql/indexer.yaml
+++ b/k8s/geonames-sparql/indexer.yaml
@@ -117,6 +117,12 @@ spec:
                   echo "Creating Lucene index..."
                   jar=$(ls /fuseki/jena-fuseki-server-*.jar)
                   "$JAVA_HOME/bin/java" -Xmx6g -cp "$jar" jena.textindexer --desc=/fuseki-config/config.ttl
+                  # Make the text index group-writable so the restart-server container
+                  # (group 100 via fsGroup, but a different UID) can move it staging→
+                  # production. Renaming a directory needs write on the directory itself;
+                  # this container creates /data/index as UID 1000 mode 755, so without
+                  # this the swap fails with "mv: Permission denied".
+                  chmod -R g+w /data/index
           containers:
             - name: restart-server
               image: bitnami/kubectl:latest

--- a/k8s/geonames-sparql/reindex-job.yaml
+++ b/k8s/geonames-sparql/reindex-job.yaml
@@ -116,6 +116,12 @@ spec:
               echo "Creating Lucene index..."
               jar=$(ls /fuseki/jena-fuseki-server-*.jar) || fail "find fuseki jar"
               "$JAVA_HOME/bin/java" -Xmx6g -cp "$jar" jena.textindexer --desc=/fuseki-config/config.ttl || fail "textindexer"
+              # Make the text index group-writable so the restart-server container (group
+              # 100 via fsGroup, but a different UID) can move it staging→production.
+              # Renaming a directory needs write on the directory itself; this container
+              # creates /data/index as UID 1000 mode 755, so without this the swap fails
+              # with "mv: Permission denied" (which is exactly what bit reindex-10).
+              chmod -R g+w /data/index || fail "chmod index"
       containers:
         - name: restart-server
           image: bitnami/kubectl:latest


### PR DESCRIPTION
## Why

`reindex-10` succeeded at the hard part – it loaded all **137,687,517** triples into the production TDB store with no OOM (the bounded-sort fix works). But `restart-server` then failed to move the Lucene text index:

```
mv: cannot move '/data/staging/index' to '/data/production/index': Permission denied
```

Renaming a directory needs write permission **on the directory itself** (to update its `..` entry). `build-text-index` runs as UID 1000 and created `/data/staging/index` mode 755 (no group-write), so the `restart-server` container (group 100 via fsGroup, but a different UID) could not move it. The TDB store moved fine because `prepare-tdb` (root) had already `chmod -R g+w`’d it.

Net state: the live endpoint serves the new 137.7M-triple data, but text search returns empty. The text index **was built successfully** and still sits in `/data/staging/index`.

## What

1. **`finish-swap-job.yaml`** (one-off): runs as root, moves the already-built `/data/staging/index` → `/data/production/index`, fixes perms, and restarts Fuseki – finishing the swap without redoing the ~48-min load. Prune via GitOps once it completes.
2. **Permanent fix**: add `chmod -R g+w /data/index` at the end of `build-text-index` in both `reindex-job.yaml` and `indexer.yaml`, so future swaps can move the text index.
