### PR TITLE
fix(dkg): scope ingress rewrite to a regex path so HTTP-01 (cert) works

### DIFF
--- a/k8s/dataset-knowledge-graph/qlever.yaml
+++ b/k8s/dataset-knowledge-graph/qlever.yaml
@@ -212,15 +212,19 @@ spec:
       # path prefix to QLever's /sparql endpoint; the query string passes through
       # unchanged. Public endpoint:
       #   https://sparql.netwerkdigitaalerfgoed.nl/dataset-knowledge-graph
+      # The rewrite is scoped to a capture-group regex path (mirrors the proven
+      # dataset-register-api ingress) so it applies ONLY to this prefix — a plain
+      # rewrite-target rewrote every request on the host, including cert-manager's
+      # /.well-known/acme-challenge path, which broke HTTP-01 and blocked the cert.
       # NOTE: on a shared host exactly one Ingress may own the TLS certificate;
       # whichever service is added first owns it, the rest reuse the secret.
       - hosts:
           - sparql.netwerkdigitaalerfgoed.nl
         annotations:
-          nginx.ingress.kubernetes.io/rewrite-target: /sparql
+          nginx.ingress.kubernetes.io/rewrite-target: /sparql$2
         paths:
-          - path: /dataset-knowledge-graph
-            pathType: Prefix
+          - path: /dataset-knowledge-graph(/|$)(.*)
+            pathType: ImplementationSpecific
 
     configMaps:
       - name: qleverfile


### PR DESCRIPTION
The static `rewrite-target: /sparql` rewrote **every** request on `sparql.netwerkdigitaalerfgoed.nl`, including cert-manager's `/.well-known/acme-challenge/<token>` path. The ACME solver logged `path="/sparql" token="sparql" → invalid base_path`, so HTTP-01 validation looped forever and the Let's Encrypt cert never issued (browser saw the temporary `cert-manager.local` cert). Scope the rewrite to a capture-group regex path (`/dataset-knowledge-graph(/|$)(.*)` → `/sparql$2`), mirroring the proven `dataset-register-api` ingress, so only the DKG prefix is rewritten and the ACME path is left intact.