### PR TITLE
fix(dkg): disable Helm wait for the build-on-start QLever release

### DIFF
--- a/k8s/dataset-knowledge-graph/qlever.yaml
+++ b/k8s/dataset-knowledge-graph/qlever.yaml
@@ -21,7 +21,14 @@ metadata:
 spec:
   serviceAccountName: nde
   interval: 30m
+  # This pod builds its index on start, so it is not Ready immediately. Don't let
+  # Helm block on readiness during install/upgrade — otherwise the 5m wait times
+  # out (worsened by the cluster's client rate limiter), the release is marked
+  # failed, and the new spec never sticks. K8s readiness still gates traffic.
+  install:
+    disableWait: true
   upgrade:
+    disableWait: true
     remediation:
       remediateLastFailure: false
   chart:


### PR DESCRIPTION
The QLever pod builds its index on startup, so it isn't Ready immediately. Helm's default 5m readiness wait (compounded by the cluster's client rate limiter -> `context deadline exceeded`) times out, the HelmRelease is marked failed, and with `remediateLastFailure: false` the live StatefulSet/Ingress stay on the old spec — so the cold-start seed fix (#226) and ACME ingress fix (#227) never actually took effect. Set `install.disableWait`/`upgrade.disableWait` so the new spec applies immediately and the release succeeds; Kubernetes readiness still gates traffic to the Service.