### PR TITLE
Add def.nde.nl vocabulary server (definitions)

### DIFF
--- a/k8s/definitions/helmrelease.yaml
+++ b/k8s/definitions/helmrelease.yaml
@@ -1,0 +1,81 @@
+# Serves the NDE RDF vocabularies published under https://def.nde.nl/.
+#
+# A small Apache container (built from netwerk-digitaal-erfgoed/definitions)
+# serves WIDOCO-generated documentation with content negotiation: a browser
+# gets HTML, a client asking for text/turtle, application/rdf+xml,
+# application/n-triples or application/ld+json gets that serialization. Each
+# vocabulary module is a path under the host: /probe, /metric, /pid-scheme,
+# /iiif.
+#
+# Stateless and read-only: no volumes, no database. The content is baked into
+# the image at build time, so a vocabulary change ships as a new image.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: definitions
+  namespace: nde
+spec:
+  serviceAccountName: nde
+  interval: 30m
+  chart:
+    spec:
+      chart: helm/nde-app
+      reconcileStrategy: Revision
+      sourceRef:
+        kind: GitRepository
+        name: nde
+  values:
+    containers:
+      - name: app
+        image:
+          repository: ghcr.io/netwerk-digitaal-erfgoed/definitions
+          tag: latest
+        # The image is rebuilt and pushed on every push to main. `Always` pulls
+        # the newest image when a pod starts, so a vocabulary change is picked up
+        # by a rollout restart (or the next reschedule). If we later publish
+        # semver image tags, this can move to Flux image automation like
+        # geonames-sparql.
+        imagePullPolicy: Always
+        port: 80
+        resources:
+          # Static file serving with Apache; tiny footprint.
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi
+        # `/probe/` negotiates to a 303, which counts as a successful httpGet
+        # probe (any status < 400), and proves the .htaccess rewrite is live.
+        startupProbe:
+          httpGet:
+            path: /probe/
+            port: 80
+          periodSeconds: 5
+          failureThreshold: 12
+        livenessProbe:
+          httpGet:
+            path: /probe/
+            port: 80
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /probe/
+            port: 80
+
+    service:
+      port: 80
+      targetPort: 80
+
+    ingresses:
+      # def.nde.nl is a new apex under nde.nl (not *.netwerkdigitaalerfgoed.nl).
+      # The chart enables TLS by default and cert-manager issues a per-host
+      # certificate (secret definitions-tls) once def.nde.nl resolves to the
+      # cluster ingress, so DNS for def.nde.nl is a prerequisite for the cert.
+      - ingressClassName: nginx-shared
+        hosts:
+          - def.nde.nl
+        paths:
+          - path: /
+            pathType: Prefix


### PR DESCRIPTION
Deploys the NDE RDF vocabularies under `https://def.nde.nl/` on the SURF cluster.

A small Apache container (built from [`netwerk-digitaal-erfgoed/definitions`](https://github.com/netwerk-digitaal-erfgoed/definitions)) serves WIDOCO-generated documentation with content negotiation: a browser gets HTML, a client asking for `text/turtle`, `application/rdf+xml`, `application/n-triples` or `application/ld+json` gets that serialization. Modules are paths under the host: `/probe`, `/metric`, `/pid-scheme`, `/iiif`.

A new `k8s/definitions/helmrelease.yaml` on the shared `helm/nde-app` chart, mirroring `dataset-knowledge-graph` and `geonames-sparql`. Stateless and read-only — no volumes, no database; content is baked into the image.

### How it stays current
- **Image automation:** the `definitions` CI publishes a 14-digit timestamp tag (`YYYYMMDDHHmmss`), which the chart’s default numerical `ImagePolicy` tracks; Flux bumps the `tag:` line on every push and the change auto-deploys within ~1 minute. Same pattern as `dataset-register-browser`.
- **Private image is fine:** the chart auto-adds the `ghcr` `imagePullSecret`, so the package does not need to be public.
- **DNS:** ExternalDNS creates the record from the Ingress host `def.nde.nl` (requires `nde.nl` to be a zone ExternalDNS manages).
- **TLS:** cert-manager issues a per-host cert (`definitions-tls`) once `def.nde.nl` resolves to the cluster ingress.

Once merged, this also makes the `w3id.org/nde` → `def.nde.nl` redirect (perma-id/w3id.org#6187) resolve.
