### PR TITLE
Auto-deploy definitions via Flux image automation

### DIFF
--- a/k8s/definitions/helmrelease.yaml
+++ b/k8s/definitions/helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
           # every push, so a vocabulary change auto-deploys within ~1 minute. The
           # chart auto-adds the `ghcr` imagePullSecret, so the package can stay
           # private.
-          tag: "20260611123148" # {"$imagepolicy": "nde:definitions:tag"}
+          tag: "20260611130149" # {"$imagepolicy": "nde:definitions:tag"}
         port: 80
         resources:
           # Static file serving with Apache; tiny footprint.

--- a/k8s/definitions/helmrelease.yaml
+++ b/k8s/definitions/helmrelease.yaml
@@ -29,13 +29,12 @@ spec:
       - name: app
         image:
           repository: ghcr.io/netwerk-digitaal-erfgoed/definitions
-          tag: latest
-        # The image is rebuilt and pushed on every push to main. `Always` pulls
-        # the newest image when a pod starts, so a vocabulary change is picked up
-        # by a rollout restart (or the next reschedule). If we later publish
-        # semver image tags, this can move to Flux image automation like
-        # geonames-sparql.
-        imagePullPolicy: Always
+          # Flux tracks the 14-digit timestamp tags the definitions CI publishes
+          # (the chart's default numerical image policy) and bumps this line on
+          # every push, so a vocabulary change auto-deploys within ~1 minute. The
+          # chart auto-adds the `ghcr` imagePullSecret, so the package can stay
+          # private.
+          tag: "20260611123148" # {"$imagepolicy": "nde:definitions:tag"}
         port: 80
         resources:
           # Static file serving with Apache; tiny footprint.


### PR DESCRIPTION
Follow-up to #231, which merged with `tag: latest`. That works (the pod pulls `:latest` via the auto-wired `ghcr` secret), but the chart turns on a default numerical `ImagePolicy` for the container, and `latest` carries no image-automation marker – so new vocabulary images never roll out automatically.

This switches the container to the image-automation convention the chart is built for (and that `dataset-register-browser` already uses):

- The `definitions` CI now publishes a 14-digit timestamp tag (`YYYYMMDDHHmmss`); see netwerk-digitaal-erfgoed/definitions@123c143.
- The `tag:` here is pinned to a real published tag and annotated with `# {"$imagepolicy": "nde:definitions:tag"}`, so Flux’s `ImageUpdateAutomation` bumps it on every push and the change auto-deploys within ~1 minute.
- Dropped `imagePullPolicy: Always` – immutable timestamp tags make it unnecessary.

No behavioural change beyond enabling automatic rollout of vocabulary updates.
