### PR TITLE
Do not block the definitions release on pod readiness (disableWait)

### DIFF
--- a/k8s/definitions/helmrelease.yaml
+++ b/k8s/definitions/helmrelease.yaml
@@ -17,6 +17,14 @@ metadata:
 spec:
   serviceAccountName: nde
   interval: 30m
+  # Do not block the release on pod readiness. Kubernetes still gates traffic on
+  # the readiness probe; this just stops a slow or temporarily failing image pull
+  # from timing out the helm upgrade and wedging the release until the next 30m
+  # reconcile (as `dataset-knowledge-graph-qlever` and `geonames-sparql` do).
+  install:
+    disableWait: true
+  upgrade:
+    disableWait: true
   chart:
     spec:
       chart: helm/nde-app


### PR DESCRIPTION
Sets `install.disableWait` / `upgrade.disableWait` on the `definitions` HelmRelease, matching `dataset-knowledge-graph-qlever` and `geonames-sparql`.

Without it, a HelmRelease upgrade runs `helm upgrade --wait` and blocks on pod readiness. When the new pod could not become ready (it was ImagePullBackOff while the `definitions` ghcr package was still private), the upgrade timed out, was marked failed, and — with the default `remediation.retries: 0` — would not retry until the next 30m reconcile, leaving the old image serving.

`disableWait` lets Flux apply the change and return immediately; Kubernetes still gates real traffic on the readiness probe, so a slow or briefly failing pull no longer wedges the release.

Merging this also re-applies the HelmRelease, which should kick the currently-stuck rollout (image `20260611130149`, now public) loose.
