### PR TITLE
feat(dkg): enable dataset skipping via provenance store

### DIFF
--- a/k8s/dataset-knowledge-graph/helmrelease.yaml
+++ b/k8s/dataset-knowledge-graph/helmrelease.yaml
@@ -42,6 +42,17 @@ spec:
             value: /data/nq
           - name: OUTPUT_VALIDATION_CACHE_DIR
             value: /data/validation/nq
+          # Per-dataset processing records (provenance) for skipping unchanged
+          # datasets: written here for the serving QLever to index (see
+          # qlever.yaml's Qleverfile), and read back from the served endpoint
+          # below at the start of the next run.
+          - name: OUTPUT_PROVENANCE_CACHE_DIR
+            value: /data/provenance/nq
+          # The served (read-only) QLever the skip gate queries for the previous
+          # run's records. Setting this activates dataset skipping; unset, every
+          # dataset is reprocessed.
+          - name: SERVED_SPARQL_ENDPOINT
+            value: https://sparql.netwerkdigitaalerfgoed.nl/dataset-knowledge-graph
           - name: REBUILD_SENTINEL_PATH
             value: /data/nq/.rebuild
         volumeMounts:

--- a/k8s/dataset-knowledge-graph/qlever.yaml
+++ b/k8s/dataset-knowledge-graph/qlever.yaml
@@ -98,7 +98,7 @@ spec:
 
             # The pipeline writes here; make sure the directories exist so the
             # first boot (before any pipeline run) and the input glob both work.
-            mkdir -p nq validation/nq
+            mkdir -p nq validation/nq provenance/nq
 
             start_server() {
               qlever start
@@ -113,7 +113,7 @@ spec:
             # as real n-quads exist, so it never appears in a populated index.
             BOOTSTRAP=nq/_bootstrap.nq
             seed_if_empty() {
-              if find nq validation/nq -name '*.nq' ! -name '_bootstrap.nq' \
+              if find nq validation/nq provenance/nq -name '*.nq' ! -name '_bootstrap.nq' \
                    -print -quit 2>/dev/null | grep -q .; then
                 rm -f "$BOOTSTRAP"
               else
@@ -263,11 +263,13 @@ spec:
             FORMAT           = nq
 
             [index]
-            # One named graph per analysed dataset (summaries) plus the derived
-            # SHACL validation graphs. `find` tolerates missing dirs/files so an
-            # empty or partial cache still indexes.
-            INPUT_FILES      = nq/*.nq validation/nq/*.nq
-            CAT_INPUT_FILES  = find nq validation/nq -name '*.nq' -exec cat {} +
+            # One named graph per analysed dataset (summaries), the derived
+            # SHACL validation graphs, and the pipeline's provenance graph (the
+            # per-dataset processing records the skip gate reads back). `find`
+            # tolerates missing dirs/files so an empty or partial cache still
+            # indexes.
+            INPUT_FILES      = nq/*.nq validation/nq/*.nq provenance/nq/*.nq
+            CAT_INPUT_FILES  = find nq validation/nq provenance/nq -name '*.nq' -exec cat {} +
             SETTINGS_JSON    = { "ascii-prefixes-only": false, "num-triples-per-batch": 100000 }
             TEXT_INDEX       = none
 


### PR DESCRIPTION
## What

Activates the **skip-unchanged-datasets** feature ([lde#450](https://github.com/ldelements/lde/issues/450)) for the DKG in production. Pairs with [dataset-knowledge-graph#333](https://github.com/netwerk-digitaal-erfgoed/dataset-knowledge-graph/pull/333), which wires the provenance store into the pipeline (gated on `SERVED_SPARQL_ENDPOINT`).

## Changes

**`helmrelease.yaml`** — two env vars on the pipeline container:
- `SERVED_SPARQL_ENDPOINT=https://sparql.netwerkdigitaalerfgoed.nl/dataset-knowledge-graph` — the served read-only QLever the skip gate queries for the previous run's records. Setting it is what activates skipping.
- `OUTPUT_PROVENANCE_CACHE_DIR=/data/provenance/nq` — on the shared PVC (the dev default `output/provenance/nq` would land on ephemeral container storage), so the records persist for the serving QLever to index.

**`qlever.yaml`** — the serving QLever indexes input dirs **explicitly**, so it must be told about the new dir:
- Qleverfile `INPUT_FILES` / `CAT_INPUT_FILES`: add `provenance/nq`.
- startup `mkdir -p` and the cold-cache bootstrap `find`: add `provenance/nq`.

Without the `qlever.yaml` half, the records would be written but never indexed/queryable, so `get()` would always find nothing and the gate would never skip (safe, but the feature would be inert).

## How it works

The pipeline writes one provenance n-quads file per dataset into `/data/provenance/nq`, each record in the graph `https://sparql.netwerkdigitaalerfgoed.nl/dataset-knowledge-graph/provenance`. The serving QLever rebuilds its index (post-run, via the existing sentinel) including that dir. The next run's gate queries the served endpoint for each dataset's record and skips it when the source fingerprint and pipeline version both match — before importing.

## Rollout / safety

- **First run after this lands reprocesses everything** (no records yet → baseline), then subsequent runs skip unchanged datasets.
- A store read failure falls through to reprocessing — it never crashes the run.
- Mirrors the existing `OUTPUT_VALIDATION_CACHE_DIR` pattern (separate dir on the same PVC, indexed alongside the data).

## Follow-up

- Extend the pipeline's `pruneOrphanedGraphs` to also prune the provenance dir for removed datasets — [dataset-knowledge-graph#335](https://github.com/netwerk-digitaal-erfgoed/dataset-knowledge-graph/issues/335).
