### PR TITLE
Fix definitions health probes (CrashLoopBackOff)

### DIFF
--- a/k8s/definitions/helmrelease.yaml
+++ b/k8s/definitions/helmrelease.yaml
@@ -52,23 +52,24 @@ spec:
           limits:
             cpu: 500m
             memory: 256Mi
-        # `/probe/` negotiates to a 303, which counts as a successful httpGet
-        # probe (any status < 400), and proves the .htaccess rewrite is live.
+        # Probe a static file that returns 200 directly. Do NOT probe `/probe/`:
+        # it 303-redirects to an https URL, which the kubelet follows into plain
+        # TLS on port 80 and fails, killing the pod (CrashLoopBackOff).
         startupProbe:
           httpGet:
-            path: /probe/
+            path: /probe/index-en.html
             port: 80
           periodSeconds: 5
           failureThreshold: 12
         livenessProbe:
           httpGet:
-            path: /probe/
+            path: /probe/index-en.html
             port: 80
           timeoutSeconds: 5
           failureThreshold: 3
         readinessProbe:
           httpGet:
-            path: /probe/
+            path: /probe/index-en.html
             port: 80
 
     service:


### PR DESCRIPTION
The startup/liveness/readiness probes hit `/probe/`, which now 303-redirects to an https URL (the conneg fix). The kubelet follows that redirect into plain TLS on port 80, the probe fails, and the pod is killed every ~60s → CrashLoopBackOff → ingress 503. Point the probes at the static `/probe/index-en.html` (returns 200, no redirect) instead.