### PR TITLE
refactor(dataset-register): point OTLP exporter at shared nde-otel collector

### DIFF
--- a/k8s/dataset-register/api.yaml
+++ b/k8s/dataset-register/api.yaml
@@ -32,7 +32,7 @@ spec:
           - name: TRUST_PROXY
             value: "true"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: "http://opentelemetry-collector:4318"
+            value: "http://nde-otel.monitoring.svc.cluster.local:4318"
           - name: OTEL_LOG_LEVEL
             value: "all"
           - name: API_ACCESS_TOKEN

--- a/k8s/dataset-register/crawler.yaml
+++ b/k8s/dataset-register/crawler.yaml
@@ -30,7 +30,7 @@ spec:
           - name: CRAWLER_SCHEDULE
             value: "0 * * * *"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: "http://opentelemetry-collector:4318"
+            value: "http://nde-otel.monitoring.svc.cluster.local:4318"
         resources:
           requests:
             cpu: "500m"


### PR DESCRIPTION
Our k8s provider provisioned a shared OpenTelemetry collector (Grafana Tempo) at `nde-otel.monitoring.svc.cluster.local` (gRPC `:4317`, HTTP `:4318`).

This points the dataset-register `OTEL_EXPORTER_OTLP_ENDPOINT` at that collector instead of the old in-namespace `opentelemetry-collector` service.

## Changes

- `k8s/dataset-register/api.yaml` – update OTLP endpoint
- `k8s/dataset-register/crawler.yaml` – update OTLP endpoint

## Notes

- Kept OTLP/HTTP on port `4318`, matching the existing exporter configuration (no app-side protocol change needed).
- Used the fully-qualified service name so it resolves across namespaces (collector lives in `monitoring`, apps in `nde`).

Ref #93