### PR TITLE
Assign pod priority to user-facing apps and SPARQL stores

### DIFF
--- a/helm/nde-app/templates/cronjob.yaml
+++ b/helm/nde-app/templates/cronjob.yaml
@@ -29,6 +29,9 @@ spec:
           imagePullSecrets:
             - name: ghcr
           {{- end }}
+          {{- with .priorityClassName }}
+          priorityClassName: {{ . }}
+          {{- end }}
           {{- with .securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/helm/nde-app/templates/workload.yaml
+++ b/helm/nde-app/templates/workload.yaml
@@ -49,6 +49,9 @@ spec:
         - name: ghcr
         {{- end }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/helm/nde-app/values.yaml
+++ b/helm/nde-app/values.yaml
@@ -39,6 +39,10 @@ containers: []
 # Image pull secrets (ghcr.io images auto-add ghcr secret)
 imagePullSecrets: []
 
+# Pod priority. References a PriorityClass (see k8s/priority-classes); empty
+# leaves the pod at the cluster default priority of 0.
+priorityClassName: ""
+
 # Pod security context
 securityContext: {}
   # fsGroup: 82

--- a/k8s/dataset-knowledge-graph/qlever.yaml
+++ b/k8s/dataset-knowledge-graph/qlever.yaml
@@ -39,6 +39,7 @@ spec:
         kind: GitRepository
         name: nde
   values:
+    priorityClassName: nde-high
     workload:
       type: statefulset
 

--- a/k8s/dataset-register/api.yaml
+++ b/k8s/dataset-register/api.yaml
@@ -13,6 +13,7 @@ spec:
         kind: GitRepository
         name: nde
   values:
+    priorityClassName: nde-high
     workload:
       replicas: 2
     containers:

--- a/k8s/dataset-register/browser.yaml
+++ b/k8s/dataset-register/browser.yaml
@@ -13,6 +13,7 @@ spec:
         kind: GitRepository
         name: nde
   values:
+    priorityClassName: nde-high
     workload:
       replicas: 2
     containers:

--- a/k8s/dataset-register/qlever.yaml
+++ b/k8s/dataset-register/qlever.yaml
@@ -16,6 +16,7 @@ spec:
         kind: GitRepository
         name: nde
   values:
+    priorityClassName: nde-high
     workload:
       type: statefulset
 

--- a/k8s/geonames-sparql/helmrelease.yaml
+++ b/k8s/geonames-sparql/helmrelease.yaml
@@ -24,6 +24,7 @@ spec:
     # of patching. Bypasses StatefulSet rollouts that are stuck mid-update.
     force: true
   values:
+    priorityClassName: nde-high
     workload:
       type: statefulset
 

--- a/k8s/network-of-terms-demo/helmrelease.yaml
+++ b/k8s/network-of-terms-demo/helmrelease.yaml
@@ -14,6 +14,7 @@ spec:
         kind: GitRepository
         name: nde
   values:
+    priorityClassName: nde-high
     workload:
       replicas: 2
     containers:

--- a/k8s/network-of-terms/status-postgres.yaml
+++ b/k8s/network-of-terms/status-postgres.yaml
@@ -14,6 +14,7 @@ spec:
         kind: GitRepository
         name: nde
   values:
+    priorityClassName: nde-high
     workload:
       type: statefulset
     containers:

--- a/k8s/network-of-terms/status.yaml
+++ b/k8s/network-of-terms/status.yaml
@@ -13,6 +13,7 @@ spec:
         kind: GitRepository
         name: nde
   values:
+    priorityClassName: nde-high
     workload:
       replicas: 1
     containers:

--- a/k8s/priority-classes/priority-classes.yaml
+++ b/k8s/priority-classes/priority-classes.yaml
@@ -1,0 +1,21 @@
+# Pod priority classes for the nde namespace.
+#
+# Kubernetes schedules higher-value pods first and, under resource pressure,
+# preempts (evicts) lower-value pods to make room for them. Pods without a
+# priorityClassName stay at the cluster default priority of 0, so a single
+# explicit high tier is enough to let user-facing workloads win against
+# background and batch work.
+#
+# Values stay well below the reserved system tiers (system-cluster-critical is
+# 2000000000) so cluster components always outrank application pods.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: nde-high
+value: 1000000
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: >-
+  User-facing applications (Network of Terms, Dataset Register) and the SPARQL
+  stores that back them. Scheduled ahead of, and able to preempt, background and
+  batch workloads when the nde namespace is under resource pressure.


### PR DESCRIPTION
## What

Assign Kubernetes Pod Priority so user-facing services win scheduling against background and batch work when the nde namespace is under resource pressure.

- New `nde-high` PriorityClass (value `1000000`, below the reserved system tiers; `preemptionPolicy: PreemptLowerPriority`).
- Optional `priorityClassName` value added to the `nde-app` Helm chart, wired into both the workload (Deployment/StatefulSet) and CronJob pod specs. Empty by default, so unmarked workloads are unchanged.
- `priorityClassName: nde-high` applied to the user-facing apps and the SPARQL stores that back them.

Everything else stays at the cluster default priority of `0`, so the DKG pipeline, GeoNames reindexer, and import/cleanup jobs yield first.

## Workloads promoted to `nde-high`

| Workload | Why |
| --- | --- |
| `network-of-terms-demo` | serves production `termennetwerk.netwerkdigitaalerfgoed.nl` |
| `network-of-terms-status` + `status-postgres` | status app and its datastore |
| `dataset-register-api`, `dataset-register-browser` | Dataset Register front + API |
| `dataset-register-qlever` | SPARQL store backing the Dataset Register |
| `dataset-knowledge-graph-qlever` | read-only SPARQL store serving the DKG |
| `geonames-sparql` | Fuseki SPARQL source queried by Network of Terms |

A high-priority app and its datastore share the tier, otherwise the scheduler could preempt the default-priority database out from under a protected app.

## Validation

- `helm template` confirms `priorityClassName` renders on the Deployment, StatefulSet, and CronJob paths, and is absent when unset.
- `helm lint` passes.

## Notes

- The Flux `kustomize-controller` service account needs permission to create the cluster-scoped `PriorityClass` resource.
- `graphdb` (`triplestore.netwerkdigitaalerfgoed.nl`) is left at default for now; easy to promote later.
- An optional negative-value `nde-low` tier could later make batch jobs the first to be preempted, beyond the default `0` baseline.

Closes #88
