### PR TITLE
chore(status): disable RUN_ON_START for network-of-terms-status

### DIFF
--- a/k8s/network-of-terms/status.yaml
+++ b/k8s/network-of-terms/status.yaml
@@ -34,6 +34,12 @@ spec:
                 key: credentials
           - name: LDES_BASE_URL
             value: https://status.termennetwerk.netwerkdigitaalerfgoed.nl
+          # Serve the observations already persisted in Postgres immediately on
+          # restart; the periodic cron refreshes them within POLLING_INTERVAL_SECONDS.
+          # Keeps the initial check and its materialized-view refresh off the
+          # startup critical path (they blocked the server from listening before).
+          - name: RUN_ON_START
+            value: 'false'
     ingresses:
       - hosts:
           - status.termennetwerk.netwerkdigitaalerfgoed.nl


### PR DESCRIPTION
## Why

`network-of-terms-status` persists every observation in Postgres, and the GraphQL layer reads the last-known availabilities from the `latest_observations` materialized view. So on a restart there is **already** recent data to serve — no need to run a fresh check before accepting traffic.

With `RUN_ON_START` at its default (`true`), startup instead `await`s a full initial check (all 56 sources) **and** a materialized-view refresh **before** `fastify.listen()`. On a recent deploy that stalled startup for hours: the materialized-view refresh waited on a database lock, so the server never bound and the public `/sources` page showed no availabilities the whole time.

## What

Set `RUN_ON_START=false` for the prod deployment. The server binds immediately and serves the persisted observations; the periodic cron refreshes them within `POLLING_INTERVAL_SECONDS` (5 min). Worst case after a restart is up to 5 min of slightly stale data — and staleness is visible (each source carries its `lastChecked` time).

## Notes

- This removes the initial check from the startup critical path; it does **not** by itself make the periodic `REFRESH` lock-safe. A follow-up will add `lock_timeout`/`statement_timeout` on the status DB connection so a contended refresh fails fast instead of hanging.
- App default stays `true` (handy for local/dev and a fresh, empty database); only the prod deployment overrides it.
