### PR TITLE
fix: tune Matomo PHP-FPM workers and MariaDB resources to stop 502/503s

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ This creates:
 - a TLS Certificate for `my-app.netwerkdigitaalerfgoed.nl`
 - a DNS entry for `my-app.netwerkdigitaalerfgoed.nl`.
 
+### Resource limits
+
+The cluster is managed by SURF, which applies a `LimitRange` to the namespace. Defaults per container, unless a HelmRelease sets its own `resources`:
+
+- Memory limit: **256M**
+- CPU: **250m**
+
 ### Image automation
 
 Flux automatically updates image tags when new versions are pushed. The `# {"$imagepolicy": ...}` comment enables this.

--- a/k8s/matomo/helmrelease-mariadb.yaml
+++ b/k8s/matomo/helmrelease-mariadb.yaml
@@ -44,9 +44,32 @@ spec:
                 key: mariadb-password
           - name: MARIADB_DATABASE
             value: matomo
+        # The SURF LimitRange default (256M) is below InnoDB’s buffer pool plus
+        # per-connection overhead, which OOM-killed MariaDB (crash recovery in the logs).
+        resources:
+          requests:
+            cpu: 100m
+            memory: 384Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
         volumeMounts:
           - name: data
             mountPath: /var/lib/mysql
+          - name: mariadb-config
+            mountPath: /etc/mysql/conf.d/zzz-matomo.cnf
+            subPath: zzz-matomo.cnf
+    volumes:
+      - name: mariadb-config
+        configMap:
+          name: matomo-mariadb-config
+    configMaps:
+      - name: config
+        data:
+          zzz-matomo.cnf: |
+            [mariadbd]
+            # Raised from the 128M default to cache more of the Matomo working set.
+            innodb_buffer_pool_size = 256M
     persistentVolumes:
       - name: data
         size: 8Gi

--- a/k8s/matomo/helmrelease.yaml
+++ b/k8s/matomo/helmrelease.yaml
@@ -85,9 +85,21 @@ spec:
                 key: SMTP_PASSWORD
           - name: MATOMO_GENERAL_NOREPLY_EMAIL_ADDRESS
             value: noreply@netwerkdigitaalerfgoed.nl
+        # The SURF LimitRange default (256M) is too low for 12 PHP-FPM workers under
+        # dashboard load, which caused upstream resets surfacing as 502/503.
+        resources:
+          requests:
+            cpu: 250m
+            memory: 256Mi
+          limits:
+            cpu: "1"
+            memory: 768Mi
         volumeMounts:
           - name: data
             mountPath: /var/www/html
+          - name: php-fpm-config
+            mountPath: /usr/local/etc/php-fpm.d/zzz-matomo.conf
+            subPath: zzz-matomo.conf
     securityContext:
       fsGroup: 82
     persistentVolumes:
@@ -97,7 +109,22 @@ spec:
       - name: nginx-config
         configMap:
           name: matomo-nginx
+      - name: php-fpm-config
+        configMap:
+          name: matomo-php-fpm
     configMaps:
+      - name: php-fpm
+        data:
+          # Sorts after the image's zz-docker.conf so these directives win.
+          # Raises the worker pool above the image default (pm.max_children = 5),
+          # which was exhausted under dashboard load and returned 502/503.
+          zzz-matomo.conf: |
+            [www]
+            pm = dynamic
+            pm.max_children = 12
+            pm.start_servers = 4
+            pm.min_spare_servers = 2
+            pm.max_spare_servers = 6
       - name: nginx
         data:
           default.conf: |


### PR DESCRIPTION
## Why

Matomo has been intermittently returning 502/503s. The cluster logs show two distinct causes:

1. **PHP-FPM worker exhaustion.** The pool repeatedly hit `server reached pm.max_children setting (5)`. Opening the dashboard fires ~8 widget requests in parallel; with only 5 workers the rest get `recv() failed (Connection reset by peer)` from the upstream, surfacing as 502/503.
2. **MariaDB OOM.** A burst of `MySQL server has gone away` / `Connection refused`, and the DB log confirms it came back up doing InnoDB crash recovery. With only the SURF `LimitRange` default of 256M memory, the buffer pool plus per-connection overhead pushes it over the limit.

## Changes

- **PHP-FPM pool** (`k8s/matomo/helmrelease.yaml`): add a `zzz-matomo.conf` drop-in ConfigMap raising `pm.max_children` 5 → 12 (sorts after the image’s `zz-docker.conf` so it wins). Set `resources` (requests 250m/256Mi, limits 1/768Mi) above the 256M default to hold the larger pool. nginx is left on the SURF defaults.
- **MariaDB** (`k8s/matomo/helmrelease-mariadb.yaml`): set `resources` (requests 100m/384Mi, limits 500m/512Mi) above the 256M default that OOM-killed it, and add a `zzz-matomo.cnf` drop-in raising `innodb_buffer_pool_size` 128M → 256M.
- **README**: document the SURF `LimitRange` defaults (256M memory, 250m CPU).

Both HelmReleases were verified by rendering with `helm template`; only the intended fields change.

## Caveat

SURF’s `LimitRange` may also impose a per-container **maximum**. If it is below `768Mi` / `1` CPU, the kustomize-controller will reject these on reconcile. The ceiling is unknown to us; if reconcile fails on a max violation we’ll lower the values or ask SURF to raise the namespace limit.
