### PR TITLE
Add Typesense search backend for the dataset register

### DIFF
--- a/k8s/dataset-register/api.yaml
+++ b/k8s/dataset-register/api.yaml
@@ -40,6 +40,17 @@ spec:
               secretKeyRef:
                 name: dataset-register-api-token
                 key: token
+          - name: TYPESENSE_HOST
+            value: "dataset-register-typesense"
+          - name: TYPESENSE_PORT
+            value: "8108"
+          - name: TYPESENSE_PROTOCOL
+            value: "http"
+          - name: TYPESENSE_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: dataset-register-typesense
+                key: api-key
         resources:
           requests:
             cpu: "250m"

--- a/k8s/dataset-register/browser.yaml
+++ b/k8s/dataset-register/browser.yaml
@@ -26,17 +26,22 @@ spec:
             value: "x-forwarded-proto"
           - name: HOST_HEADER
             value: "x-forwarded-host"
-          - name: PUBLIC_TYPESENSE_HOST
-            value: "search.datasetregister.netwerkdigitaalerfgoed.nl"
-          - name: PUBLIC_TYPESENSE_PROTOCOL
-            value: "https"
-          - name: PUBLIC_TYPESENSE_PORT
-            value: "443"
-          - name: PUBLIC_TYPESENSE_SEARCH_ONLY_API_KEY
-            valueFrom:
-              secretKeyRef:
-                name: dataset-register-typesense
-                key: search-only-api-key
+          # Typesense search cutover switch. The browser uses Typesense only when
+          # both PUBLIC_TYPESENSE_HOST and PUBLIC_TYPESENSE_SEARCH_ONLY_API_KEY
+          # are set; otherwise it falls back to SPARQL. Kept commented so the
+          # browser stays on SPARQL until the index exists and the search-only
+          # key is provisioned – uncomment to flip search to Typesense.
+          # - name: PUBLIC_TYPESENSE_HOST
+          #   value: "search.datasetregister.netwerkdigitaalerfgoed.nl"
+          # - name: PUBLIC_TYPESENSE_PROTOCOL
+          #   value: "https"
+          # - name: PUBLIC_TYPESENSE_PORT
+          #   value: "443"
+          # - name: PUBLIC_TYPESENSE_SEARCH_ONLY_API_KEY
+          #   valueFrom:
+          #     secretKeyRef:
+          #       name: dataset-register-typesense
+          #       key: search-only-api-key
     ingresses:
       - hosts:
           - datasetregister.netwerkdigitaalerfgoed.nl

--- a/k8s/dataset-register/browser.yaml
+++ b/k8s/dataset-register/browser.yaml
@@ -26,6 +26,17 @@ spec:
             value: "x-forwarded-proto"
           - name: HOST_HEADER
             value: "x-forwarded-host"
+          - name: PUBLIC_TYPESENSE_HOST
+            value: "search.datasetregister.netwerkdigitaalerfgoed.nl"
+          - name: PUBLIC_TYPESENSE_PROTOCOL
+            value: "https"
+          - name: PUBLIC_TYPESENSE_PORT
+            value: "443"
+          - name: PUBLIC_TYPESENSE_SEARCH_ONLY_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: dataset-register-typesense
+                key: search-only-api-key
     ingresses:
       - hosts:
           - datasetregister.netwerkdigitaalerfgoed.nl

--- a/k8s/dataset-register/crawler.yaml
+++ b/k8s/dataset-register/crawler.yaml
@@ -31,6 +31,17 @@ spec:
             value: "0 * * * *"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: "http://nde-otel.monitoring.svc.cluster.local:4318"
+          - name: TYPESENSE_HOST
+            value: "dataset-register-typesense"
+          - name: TYPESENSE_PORT
+            value: "8108"
+          - name: TYPESENSE_PROTOCOL
+            value: "http"
+          - name: TYPESENSE_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: dataset-register-typesense
+                key: api-key
         resources:
           requests:
             cpu: "500m"

--- a/k8s/dataset-register/typesense.yaml
+++ b/k8s/dataset-register/typesense.yaml
@@ -1,0 +1,91 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dataset-register-typesense
+spec:
+  serviceAccountName: nde
+  interval: 30m
+  chart:
+    spec:
+      chart: helm/nde-app
+      reconcileStrategy: Revision
+      sourceRef:
+        kind: GitRepository
+        name: nde
+  values:
+    workload:
+      type: statefulset
+
+    service:
+      port: 8108
+
+    containers:
+      - name: app
+        image:
+          # v30 is required: earlier versions lack Dutch stemming and the
+          # Synonym Sets API the search index relies on. Flux auto-updates within
+          # v30 only (see flux.policy); moving to v31 is a deliberate manual bump.
+          repository: typesense/typesense
+          tag: "30.2" # {"$imagepolicy": "nde:dataset-register-typesense:tag"}
+        flux:
+          enabled: true
+          policy:
+            type: semver
+            # Stable Typesense tags are 2-part (30.0, 30.1, 30.2, …). The pattern
+            # keeps only those – excluding the -arm64/-amd64 arch variants and the
+            # 31.0.rcN prereleases – and the range pins us to v30 so a v31 release
+            # is never auto-selected.
+            pattern: '^(?P<version>\d+\.\d+)$'
+            extract: '$version'
+            range: ">=30.0.0 <31.0.0"
+        port: 8108
+        env:
+          - name: TYPESENSE_DATA_DIR
+            value: "/data"
+          - name: TYPESENSE_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: dataset-register-typesense
+                key: api-key
+          - name: TYPESENSE_ENABLE_CORS
+            value: "true"
+        resources:
+          requests:
+            cpu: "250m"
+            memory: 512Mi
+          limits:
+            cpu: "1"
+            memory: 2Gi
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8108
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8108
+          timeoutSeconds: 5
+          failureThreshold: 3
+        volumeMounts:
+          - name: data
+            mountPath: /data
+
+    persistentVolumes:
+      - name: data
+        size: 10Gi
+
+    # The browser queries Typesense directly from the client with the
+    # search-only key, so it needs a publicly reachable HTTPS host. A dedicated
+    # subdomain is used because the Typesense client builds plain
+    # `protocol://host:port` URLs with no base path, so a path-prefix on the
+    # main host would not work. The first ingress gets TLS auto-configured by
+    # the chart. CORS is enabled on the server (TYPESENSE_ENABLE_CORS) so the
+    # browser app on datasetregister.netwerkdigitaalerfgoed.nl can call it.
+    ingresses:
+      - hosts:
+          - search.datasetregister.netwerkdigitaalerfgoed.nl
+        paths:
+          - path: /
+            pathType: Prefix

--- a/k8s/secrets/dataset-register-typesense.yaml
+++ b/k8s/secrets/dataset-register-typesense.yaml
@@ -1,0 +1,39 @@
+# PLACEHOLDER — NOT YET ENCRYPTED. Do not commit real keys here unencrypted.
+#
+# This holds the Typesense bootstrap (admin) key and a search-only key for the
+# browser. Before this is applied to the cluster, the operator must:
+#   1. Replace the CHANGEME values below with real keys, e.g.
+#        api-key:             $(openssl rand -hex 32)   # admin/bootstrap key
+#        search-only-api-key: <key created via the Typesense Keys API,
+#                              scoped to documents:search on the datasets
+#                              collection>
+#      The search-only key is derived after Typesense is running, using the
+#      admin key, via POST /keys (actions: ["documents:search"]).
+#   2. Encrypt the values in place with SOPS (see k8s/secrets/README.md):
+#        sops --age=age1qnjmyern7zmm5wpsclrpexu327xuqalpcthuk32hj8xn5ssts96s5hhhu8 \
+#          --encrypt --encrypted-regex '^(data|stringData)$' --in-place \
+#          dataset-register-typesense.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+    name: dataset-register-typesense
+    namespace: nde
+type: Opaque
+stringData:
+    api-key: ENC[AES256_GCM,data:n0jUSydQrn//QHrjCVYBIFFmVWYe5GVHC6I3ItGG0BghKKVNbfPv45JTOmCg9VjzVsbe3dq/7zR2qk/bFnwVGQ==,iv:MvvPe6UBZ3LIHlR8U77a8Xz8MIrxemtgXFaGR5ewLbU=,tag:1o8SpZ4Flm0ERIwQS0ljjw==,type:str]
+    search-only-api-key: ENC[AES256_GCM,data:+M1aWuBCjNU=,iv:k/QgkIwE8x/+mZbpH2ibd80Pa6ay3Ci6IccavLlpJEM=,tag:z1zMxec3Dx2H1N9hvgzJuw==,type:str]
+sops:
+    age:
+        - recipient: age1qnjmyern7zmm5wpsclrpexu327xuqalpcthuk32hj8xn5ssts96s5hhhu8
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKMEMzOTJaUnhyT1I4NUFt
+            cnNjdzhIVGVoSmxaNkwrV1FJWFQxTmR6REZ3Cko1UjlTdW1rY2twK1lpcEYxSU9D
+            YWt2aUk2V1BqZXd3ZUpGUUZidk1INmMKLS0tIEszMzVNYzg5S3B0UUd0aUwvVG5P
+            eEN1RVRkV2tBRG16MWZBeXk5V2ZyTUUKLGyvYaaQDA2for3Jl9PjL6G+O5iPOm7k
+            khsIvTMzlg9CjchrqcZ/ztcNHLyz1gWpsQmdC2L98CgTjXInIriD2g==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-20T17:56:45Z"
+    mac: ENC[AES256_GCM,data:HQpxqAasFhkFt7lH4lK+8UX6LxvePzStrJ3wTkr7fX0KjYSIW9yYDfAyd/pRaC5+JFzFhVlm8SSoaagMhCGJe8Qvm9o1rFyd/82qcTF7Zx24Y0XjXdkEUXBkg5g/EyzDUGp0E2u0Ubr6u71IXiErxoByOqOmgLgw4azA1YPlY8o=,iv:DyJgEcruYqFt9FZelniBSJW0ID3YlPyXOY1w4GN9EWE=,tag:PkMSZIhUM0N+a+Ghx9o/Pg==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2


### PR DESCRIPTION
Adds a dedicated Typesense search backend for the dataset register – the infrastructure side of the search migration (netwerk-digitaal-erfgoed/dataset-register#2085, netwerk-digitaal-erfgoed/dataset-register#2119).

## What

- **`k8s/dataset-register/typesense.yaml`** – a Typesense `HelmRelease` (`typesense/typesense:30.2`, StatefulSet, 10Gi PVC, `/health` readiness/liveness probes, CORS enabled). Dedicated to the dataset register rather than shared across apps, so its v30 pin, full blue/green rebuilds, and cross-pod rebuild lock stay isolated.
- **Flux image automation scoped to v30** – the semver policy (`>=30.0.0 <31.0.0`) plus a `^\d+\.\d+$` tag filter tracks stable v30 releases only, excluding the `-arm64`/`-amd64` arch variants and the `31.0.rcN` prereleases. v30 is required (Dutch stemming + the Synonym Sets API); moving to v31 is a deliberate manual bump.
- **Service wiring** – API + crawler use the internal Service (`dataset-register-typesense:8108`, admin key); the browser is meant to query Typesense directly with the search-only key over the DR-scoped host `search.datasetregister.netwerkdigitaalerfgoed.nl`.
- **SOPS secret** – `dataset-register-typesense` with the admin `api-key` set (encrypted to the cluster age recipient, like the sibling `dataset-register-*` secrets).

## Staged cutover

The browser uses Typesense only when `PUBLIC_TYPESENSE_HOST` + `PUBLIC_TYPESENSE_SEARCH_ONLY_API_KEY` are set; otherwise it falls back to SPARQL. Those env vars are **commented out in `browser.yaml`** so the live browser stays on SPARQL until search is actually ready:

1. **Merge** → the Typesense server, api/crawler wiring, and secret deploy. The browser keeps using SPARQL.
2. **Provision the search-only key** via the Typesense Keys API (admin key → `POST /keys`, scoped to `documents:search` + `documents:export`) and set `search-only-api-key` in the secret (`sops k8s/secrets/dataset-register-typesense.yaml`).
3. **Build + verify an index** (crawl / index trigger).
4. **Uncomment `PUBLIC_TYPESENSE_*` in `browser.yaml`** → deliberate, instant cutover to Typesense, no empty-search window.

DNS + TLS for `search.datasetregister.netwerkdigitaalerfgoed.nl` are auto-provisioned by ExternalDNS + cert-manager from the ingress – nothing manual.
