### PR TITLE
Set the dataset-register Typesense search-only key

### DIFF
--- a/k8s/secrets/dataset-register-typesense.yaml
+++ b/k8s/secrets/dataset-register-typesense.yaml
@@ -1,18 +1,7 @@
-# PLACEHOLDER — NOT YET ENCRYPTED. Do not commit real keys here unencrypted.
-#
-# This holds the Typesense bootstrap (admin) key and a search-only key for the
-# browser. Before this is applied to the cluster, the operator must:
-#   1. Replace the CHANGEME values below with real keys, e.g.
-#        api-key:             $(openssl rand -hex 32)   # admin/bootstrap key
-#        search-only-api-key: <key created via the Typesense Keys API,
-#                              scoped to documents:search on the datasets
-#                              collection>
-#      The search-only key is derived after Typesense is running, using the
-#      admin key, via POST /keys (actions: ["documents:search"]).
-#   2. Encrypt the values in place with SOPS (see k8s/secrets/README.md):
-#        sops --age=age1qnjmyern7zmm5wpsclrpexu327xuqalpcthuk32hj8xn5ssts96s5hhhu8 \
-#          --encrypt --encrypted-regex '^(data|stringData)$' --in-place \
-#          dataset-register-typesense.yaml
+# SOPS-encrypted (age). Typesense credentials for the dataset register.
+#   api-key             - bootstrap/admin key (TYPESENSE_API_KEY; api + crawler).
+#   search-only-api-key - read-only key the browser uses (documents:search + export).
+# Edit with: sops k8s/secrets/dataset-register-typesense.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -20,20 +9,20 @@ metadata:
     namespace: nde
 type: Opaque
 stringData:
-    api-key: ENC[AES256_GCM,data:n0jUSydQrn//QHrjCVYBIFFmVWYe5GVHC6I3ItGG0BghKKVNbfPv45JTOmCg9VjzVsbe3dq/7zR2qk/bFnwVGQ==,iv:MvvPe6UBZ3LIHlR8U77a8Xz8MIrxemtgXFaGR5ewLbU=,tag:1o8SpZ4Flm0ERIwQS0ljjw==,type:str]
-    search-only-api-key: ENC[AES256_GCM,data:+M1aWuBCjNU=,iv:k/QgkIwE8x/+mZbpH2ibd80Pa6ay3Ci6IccavLlpJEM=,tag:z1zMxec3Dx2H1N9hvgzJuw==,type:str]
+    api-key: ENC[AES256_GCM,data:f/ZMgkY3j1WOe08K42668p7hUB4KGZ/bEpjlrhywIKCG2Lmo5WZLe/zr3sm3X1udccbHbHIH7aCTZFK7t6F8Sg==,iv:b79Drd4GR3la5NP5vIYaiK4ara/eYhTD7nUfWSPpl/I=,tag:uZOZNLnrc17NjPBI7M3jcA==,type:str]
+    search-only-api-key: ENC[AES256_GCM,data:cAkE6zhXy9PAmI2e3VUTDMoZ22FLV92SJymTsp3dPQ9AxFAgC+eOn57YmSVVlqZF4olJOX8jdFvoSZNp2wV6aQ==,iv:oxvE90Q/QutY9DSIKuyoqgfRG0dpDqUCPmfBxkeCxbg=,tag:td1g43+JbY3Jns/OVir4tw==,type:str]
 sops:
     age:
         - recipient: age1qnjmyern7zmm5wpsclrpexu327xuqalpcthuk32hj8xn5ssts96s5hhhu8
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKMEMzOTJaUnhyT1I4NUFt
-            cnNjdzhIVGVoSmxaNkwrV1FJWFQxTmR6REZ3Cko1UjlTdW1rY2twK1lpcEYxSU9D
-            YWt2aUk2V1BqZXd3ZUpGUUZidk1INmMKLS0tIEszMzVNYzg5S3B0UUd0aUwvVG5P
-            eEN1RVRkV2tBRG16MWZBeXk5V2ZyTUUKLGyvYaaQDA2for3Jl9PjL6G+O5iPOm7k
-            khsIvTMzlg9CjchrqcZ/ztcNHLyz1gWpsQmdC2L98CgTjXInIriD2g==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOd3VFdFVOZnEwdHg3WlAz
+            L3gzMmpGdFl4OUsybENraExlNktzSFd5enpJCmVaVzFjL0hGS2ZMMDUwbWhpVHNY
+            WHBnZ2JqTHFEbUJod2wzQ1BFdVMvbE0KLS0tIFFWUC9XZ0hJV0ZxMzluS1dzNFBS
+            d1BLNE1admJRYm9oQmxMdXdNVWp6ak0K4bsaJuAOtTB2q261DpxDx5It8hIh3deW
+            WDNyo32drjz9ehYxeVKi5APrj0LOmTkpxMLrsXL4DpHp24MwVW5RJA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-20T17:56:45Z"
-    mac: ENC[AES256_GCM,data:HQpxqAasFhkFt7lH4lK+8UX6LxvePzStrJ3wTkr7fX0KjYSIW9yYDfAyd/pRaC5+JFzFhVlm8SSoaagMhCGJe8Qvm9o1rFyd/82qcTF7Zx24Y0XjXdkEUXBkg5g/EyzDUGp0E2u0Ubr6u71IXiErxoByOqOmgLgw4azA1YPlY8o=,iv:DyJgEcruYqFt9FZelniBSJW0ID3YlPyXOY1w4GN9EWE=,tag:PkMSZIhUM0N+a+Ghx9o/Pg==,type:str]
+    lastmodified: "2026-06-20T19:42:58Z"
+    mac: ENC[AES256_GCM,data:miX7mDeMRom7sctSO/NEBALjLwRHgsai3zAvILIDDUlhEIGRzSTzp8PW8sXK/3/pPdV6o5d89mdsD1N5tFZTLeJgcYZaMjox9hjLIK+1ESoqD0FzOMdjUJfZbNzu5FV/YZ45H4twEo+Skcp+HytstNMZHjYDTAtCDTMMQ8ulwNk=,iv:U7bP/tUvdGxMvcaJr5YInwPzsPlGPaRkUVX7CH2f4e8=,tag:pnpMwAb0R+oA+jadiH+lxQ==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.10.2


### PR DESCRIPTION
Registers a read-only Typesense key (`documents:search` + `documents:export`, collections `*`) via the Keys API and stores it as `search-only-api-key` in the secret; the admin `api-key` is unchanged (re-encrypted). Verified against the live host: the key is accepted for search + export (404 = valid key, collection not built yet). Prep only — the browser `PUBLIC_TYPESENSE_*` env stays commented until an index is built, so nothing flips live.