### PR TITLE
Pin browser image + set Typesense env for the dataset-register cutover

### DIFF
--- a/k8s/dataset-register/browser.yaml
+++ b/k8s/dataset-register/browser.yaml
@@ -19,29 +19,33 @@ spec:
       - name: app
         image:
           repository: ghcr.io/netwerk-digitaal-erfgoed/dataset-register/apps-browser
-          tag: 20260619054537-7c9404f # {"$imagepolicy": "nde:dataset-register-browser:tag"}
+          # Browser auto-update is PAUSED for the Typesense cutover: the image-policy
+          # setter is removed so this tag stays pinned while the crawler builds the
+          # index after #2119 merges. To resume (the cutover), re-add the setter
+          # comment for policy nde:dataset-register-browser:tag on the tag line
+          # below (see api.yaml for the exact format).
+          tag: 20260619054537-7c9404f
         port: 3000
         env:
           - name: PROTOCOL_HEADER
             value: "x-forwarded-proto"
           - name: HOST_HEADER
             value: "x-forwarded-host"
-          # Typesense search cutover switch. The browser uses Typesense only when
-          # both PUBLIC_TYPESENSE_HOST and PUBLIC_TYPESENSE_SEARCH_ONLY_API_KEY
-          # are set; otherwise it falls back to SPARQL. Kept commented so the
-          # browser stays on SPARQL until the index exists and the search-only
-          # key is provisioned – uncomment to flip search to Typesense.
-          # - name: PUBLIC_TYPESENSE_HOST
-          #   value: "search.datasetregister.netwerkdigitaalerfgoed.nl"
-          # - name: PUBLIC_TYPESENSE_PROTOCOL
-          #   value: "https"
-          # - name: PUBLIC_TYPESENSE_PORT
-          #   value: "443"
-          # - name: PUBLIC_TYPESENSE_SEARCH_ONLY_API_KEY
-          #   valueFrom:
-          #     secretKeyRef:
-          #       name: dataset-register-typesense
-          #       key: search-only-api-key
+          # Typesense search config for the browser. The #2119 browser image has no
+          # SPARQL listing, so these must be present before that image deploys – the
+          # browser stays pinned (see the tag above) until the index is built and
+          # verified, then unpinning deploys the new image onto a ready Typesense.
+          - name: PUBLIC_TYPESENSE_HOST
+            value: "search.datasetregister.netwerkdigitaalerfgoed.nl"
+          - name: PUBLIC_TYPESENSE_PROTOCOL
+            value: "https"
+          - name: PUBLIC_TYPESENSE_PORT
+            value: "443"
+          - name: PUBLIC_TYPESENSE_SEARCH_ONLY_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: dataset-register-typesense
+                key: search-only-api-key
     ingresses:
       - hosts:
           - datasetregister.netwerkdigitaalerfgoed.nl


### PR DESCRIPTION
Prepares the zero-gap Typesense search cutover. **Merge this before netwerk-digitaal-erfgoed/dataset-register#2119.**

Why: the #2119 browser image removed the SPARQL listing entirely, so the moment it deploys the listing requires Typesense. This PR makes that safe:

- **Uncomments `PUBLIC_TYPESENSE_*`** in `browser.yaml` so the new browser image has its search config (host + the search-only key from the secret — both already on master via #245 and #246).
- **Pins the browser image** (removes the `$imagepolicy` setter on the tag) so merging #2119 does *not* auto-deploy the new browser into an empty index — the current SPARQL browser keeps serving.

Rollout:
1. Merge **this** → no change to the live browser (old image ignores the env and stays pinned).
2. Merge **#2119** → api/crawler deploy with the indexer and build the Typesense index over the internal Service; the old browser keeps serving (no empty window).
3. Verify the index has data.
4. Re-add the browser `$imagepolicy` setter on the tag line → Flux deploys the #2119 browser onto a populated, configured Typesense = cutover.
