### PR TITLE
Cut over the dataset register browser to Typesense search

### DIFF
--- a/k8s/dataset-register/browser.yaml
+++ b/k8s/dataset-register/browser.yaml
@@ -19,12 +19,7 @@ spec:
       - name: app
         image:
           repository: ghcr.io/netwerk-digitaal-erfgoed/dataset-register/apps-browser
-          # Browser auto-update is PAUSED for the Typesense cutover: the image-policy
-          # setter is removed so this tag stays pinned while the crawler builds the
-          # index after #2119 merges. To resume (the cutover), re-add the setter
-          # comment for policy nde:dataset-register-browser:tag on the tag line
-          # below (see api.yaml for the exact format).
-          tag: 20260619054537-7c9404f
+          tag: 20260619054537-7c9404f # {"$imagepolicy": "nde:dataset-register-browser:tag"}
         port: 3000
         env:
           - name: PROTOCOL_HEADER


### PR DESCRIPTION
Index is built (2625 datasets, live `datasets` alias). Re-adds the browser `$imagepolicy` setter that #247 removed to pin the browser, so Flux deploys the #2119 Typesense-backed browser onto the populated index. **This is the cutover** — the listing switches from SPARQL to Typesense. The #2119 browser image has not been deployed before (it was pinned), so the deploy will be watched and re-pinned if it misbehaves.