### PR TITLE
fix(dkg): serve RDF-validity verdicts via single OUTPUT_DIR + recursive index glob

### DIFF
--- a/k8s/dataset-knowledge-graph/helmrelease.yaml
+++ b/k8s/dataset-knowledge-graph/helmrelease.yaml
@@ -43,26 +43,21 @@ spec:
           # See netwerk-digitaal-erfgoed/dataset-knowledge-graph#340.
           - name: QLEVER_MEMORY_MAX_SIZE
             value: "12G"
-          # Output store: write one n-quads file per dataset onto the shared
-          # volume, then signal the read-only serving QLever (qlever.yaml) to
-          # rebuild. No GraphDB; the KG is rebuilt from these files each run.
-          - name: OUTPUT_CACHE_DIR
-            value: /data/nq
-          - name: OUTPUT_VALIDATION_CACHE_DIR
-            value: /data/validation/nq
-          # Per-dataset processing records (provenance) for skipping unchanged
-          # datasets: written here for the serving QLever to index (see
-          # qlever.yaml's Qleverfile), and read back from the served endpoint
-          # below at the start of the next run.
-          - name: OUTPUT_PROVENANCE_CACHE_DIR
-            value: /data/provenance/nq
+          # Output store: the pipeline writes one n-quads file per dataset onto
+          # the shared volume, then signals the read-only serving QLever
+          # (qlever.yaml) to rebuild from them. No GraphDB; the KG is rebuilt from
+          # these files each run. OUTPUT_DIR is the single root: the pipeline
+          # derives /data/nq (summaries), /data/validation/nq, /data/provenance/nq
+          # (skip-gate records, read back from the served endpoint below) and
+          # /data/validity/nq (RDF-validity verdicts) beneath it, and the QLever
+          # rebuild indexes every .nq under it (see qlever.yaml's Qleverfile).
+          - name: OUTPUT_DIR
+            value: /data
           # The served (read-only) QLever the skip gate queries for the previous
           # run's records. Setting this activates dataset skipping; unset, every
           # dataset is reprocessed.
           - name: SERVED_SPARQL_ENDPOINT
             value: https://sparql.netwerkdigitaalerfgoed.nl/dataset-knowledge-graph
-          - name: REBUILD_SENTINEL_PATH
-            value: /data/nq/.rebuild
         volumeMounts:
           - mountPath: /app/imports
             name: imports

--- a/k8s/dataset-knowledge-graph/helmrelease.yaml
+++ b/k8s/dataset-knowledge-graph/helmrelease.yaml
@@ -47,9 +47,9 @@ spec:
           # the shared volume, then signals the read-only serving QLever
           # (qlever.yaml) to rebuild from them. No GraphDB; the KG is rebuilt from
           # these files each run. OUTPUT_DIR is the single root: the pipeline
-          # derives /data/nq (summaries), /data/validation/nq, /data/provenance/nq
+          # derives /data/summaries, /data/validation, /data/provenance
           # (skip-gate records, read back from the served endpoint below) and
-          # /data/validity/nq (RDF-validity verdicts) beneath it, and the QLever
+          # /data/validity (RDF-validity verdicts) beneath it, and the QLever
           # rebuild indexes every .nq under it (see qlever.yaml's Qleverfile).
           - name: OUTPUT_DIR
             value: /data

--- a/k8s/dataset-knowledge-graph/qlever.yaml
+++ b/k8s/dataset-knowledge-graph/qlever.yaml
@@ -104,9 +104,12 @@ spec:
             # writes the index files (index.*) alongside it here.
             cp /config/Qleverfile Qleverfile
 
-            # The pipeline writes here; make sure the directories exist so the
-            # first boot (before any pipeline run) and the input glob both work.
-            mkdir -p nq validation/nq provenance/nq
+            # The pipeline writes here. Only nq/ must pre-exist: it holds the
+            # bootstrap seed and the rebuild sentinel. The per-purpose
+            # subdirectories (validation/nq, provenance/nq, validity/nq) are
+            # created by the pipeline when it writes them, and the recursive
+            # index glob below finds whatever exists.
+            mkdir -p nq
 
             start_server() {
               qlever start
@@ -121,7 +124,7 @@ spec:
             # as real n-quads exist, so it never appears in a populated index.
             BOOTSTRAP=nq/_bootstrap.nq
             seed_if_empty() {
-              if find nq validation/nq provenance/nq -name '*.nq' ! -name '_bootstrap.nq' \
+              if find . -name '*.nq' ! -name '_bootstrap.nq' \
                    -print -quit 2>/dev/null | grep -q .; then
                 rm -f "$BOOTSTRAP"
               else
@@ -282,21 +285,24 @@ spec:
 
             [index]
             # CAT_INPUT_FILES is the actual data fed to the indexer: every .nq
-            # across the three graph dirs — one named graph per analysed dataset
-            # (summaries), the derived SHACL validation graphs, and the pipeline's
-            # provenance graph (the per-dataset records the skip gate reads back).
-            # `find` tolerates missing/empty dirs, so a cold or partial cache still
-            # indexes.
+            # anywhere beneath the output root (cwd is the shared volume). The
+            # pipeline writes one named graph per analysed dataset under nq/
+            # (summaries), validation/nq/ (SHACL reports), provenance/nq/ (the
+            # records the skip gate reads back) and validity/nq/ (RDF-validity
+            # verdicts). A recursive `find` indexes every output type without
+            # enumerating directories here, so a new per-dataset output dir is
+            # picked up with no change to this file; it also tolerates a cold or
+            # partial cache.
             #
             # INPUT_FILES is only qlever-control's pre-flight existence check (run
             # BEFORE CAT_INPUT_FILES); if any of its globs matches zero files the
             # build aborts with "Did you call qlever get-data?". So it is a SINGLE
             # pattern over nq/, which the bootstrap seed keeps non-empty — listing
-            # validation/ and provenance/ here too would abort whenever either is
-            # empty (cold start, or a run with no validation reports yet), even
-            # though CAT_INPUT_FILES handles them fine.
+            # the other dirs here too would abort whenever one is empty (cold
+            # start, or a run with no validation reports yet), even though
+            # CAT_INPUT_FILES handles them fine.
             INPUT_FILES      = nq/*.nq
-            CAT_INPUT_FILES  = find nq validation/nq provenance/nq -name '*.nq' -exec cat {} +
+            CAT_INPUT_FILES  = find . -name '*.nq' -exec cat {} +
             SETTINGS_JSON    = { "ascii-prefixes-only": false, "num-triples-per-batch": 100000 }
             TEXT_INDEX       = none
 

--- a/k8s/dataset-knowledge-graph/qlever.yaml
+++ b/k8s/dataset-knowledge-graph/qlever.yaml
@@ -104,12 +104,12 @@ spec:
             # writes the index files (index.*) alongside it here.
             cp /config/Qleverfile Qleverfile
 
-            # The pipeline writes here. Only nq/ must pre-exist: it holds the
-            # bootstrap seed and the rebuild sentinel. The per-purpose
-            # subdirectories (validation/nq, provenance/nq, validity/nq) are
-            # created by the pipeline when it writes them, and the recursive
-            # index glob below finds whatever exists.
-            mkdir -p nq
+            # The pipeline writes here. Only summaries/ must pre-exist: it holds
+            # the bootstrap seed and the rebuild sentinel. The other per-purpose
+            # directories (validation, provenance, validity) are created by the
+            # pipeline when it writes them, and the recursive index glob below
+            # finds whatever exists.
+            mkdir -p summaries
 
             start_server() {
               qlever start
@@ -122,7 +122,7 @@ spec:
             # graph. The server can then start and serve (empty of datasets)
             # instead of failing on a missing index. It is removed again as soon
             # as real n-quads exist, so it never appears in a populated index.
-            BOOTSTRAP=nq/_bootstrap.nq
+            BOOTSTRAP=summaries/_bootstrap.nq
             seed_if_empty() {
               if find . -name '*.nq' ! -name '_bootstrap.nq' \
                    -print -quit 2>/dev/null | grep -q .; then
@@ -179,7 +179,7 @@ spec:
               start_server
             }
 
-            SENTINEL=/data/nq/.rebuild
+            SENTINEL=/data/summaries/.rebuild
             last_scheduled_day=""
             echo "Watching $SENTINEL; daily fallback rebuild at 01:00 $TZ"
             while true; do
@@ -286,22 +286,23 @@ spec:
             [index]
             # CAT_INPUT_FILES is the actual data fed to the indexer: every .nq
             # anywhere beneath the output root (cwd is the shared volume). The
-            # pipeline writes one named graph per analysed dataset under nq/
-            # (summaries), validation/nq/ (SHACL reports), provenance/nq/ (the
-            # records the skip gate reads back) and validity/nq/ (RDF-validity
-            # verdicts). A recursive `find` indexes every output type without
-            # enumerating directories here, so a new per-dataset output dir is
-            # picked up with no change to this file; it also tolerates a cold or
+            # pipeline writes one named graph per analysed dataset under
+            # summaries/, validation/ (SHACL reports), provenance/ (the records
+            # the skip gate reads back) and validity/ (RDF-validity verdicts).
+            # A recursive `find` indexes every output type without enumerating
+            # directories here, so a new per-dataset output dir is picked up with
+            # no change to this file; matching on the `.nq` extension also means
+            # the Turtle inspection copies are skipped. It tolerates a cold or
             # partial cache.
             #
             # INPUT_FILES is only qlever-control's pre-flight existence check (run
             # BEFORE CAT_INPUT_FILES); if any of its globs matches zero files the
             # build aborts with "Did you call qlever get-data?". So it is a SINGLE
-            # pattern over nq/, which the bootstrap seed keeps non-empty — listing
-            # the other dirs here too would abort whenever one is empty (cold
-            # start, or a run with no validation reports yet), even though
+            # pattern over summaries/, which the bootstrap seed keeps non-empty —
+            # listing the other dirs here too would abort whenever one is empty
+            # (cold start, or a run with no validation reports yet), even though
             # CAT_INPUT_FILES handles them fine.
-            INPUT_FILES      = nq/*.nq
+            INPUT_FILES      = summaries/*.nq
             CAT_INPUT_FILES  = find . -name '*.nq' -exec cat {} +
             SETTINGS_JSON    = { "ascii-prefixes-only": false, "num-triples-per-batch": 100000 }
             TEXT_INDEX       = none


### PR DESCRIPTION
## ⚠️ Merge order

This **depends on** dataset-knowledge-graph PR #376 (`OUTPUT_DIR` support + the dropped `nq` segment) being released and the new image deployed to the cluster **first**. The currently deployed image does not understand `OUTPUT_DIR`; if this is applied before it, the pipeline falls back to relative output dirs and writes nowhere useful. Merge after the new DKG image is live.

## What

- **`helmrelease.yaml`**: replace `OUTPUT_CACHE_DIR`, `OUTPUT_VALIDATION_CACHE_DIR`, `OUTPUT_PROVENANCE_CACHE_DIR` and `REBUILD_SENTINEL_PATH` with a single `OUTPUT_DIR=/data`. The DKG derives `/data/summaries`, `/data/validation`, `/data/provenance` and `/data/validity` from it.
- **`qlever.yaml`**: switch the served-QLever rebuild to a recursive `find . -name '*.nq'` (Qleverfile `CAT_INPUT_FILES` and the bootstrap check), `mkdir -p summaries` only, and move the bootstrap seed / sentinel / `INPUT_FILES` to `summaries/`. Any output subdirectory is now indexed automatically.
- Dropped the redundant `nq` path segment from every output dir (everything is n-quads; the index glob matches on the `.nq` extension, so Turtle inspection copies are still skipped). The `nq` PersistentVolumeClaim **name** is left unchanged — renaming it would mean a new PVC and a full data move, which is not worth it.

## Why

The per-distribution RDF-validity verdicts – the feature that surfaces invalid-RDF dumps in the Dataset Register (e.g. issue dataset-register#2029) – were produced by the pipeline (`Wrote RDF-validity verdicts for N dataset(s)` in the logs) but **never reached the served knowledge graph**: the served endpoint has 0 `metric:distribution-rdf-valid` measurements while the SHACL-validation graphs (2704 measurements) serve fine.

Two omissions, both fixed here:
1. `OUTPUT_VALIDITY_CACHE_DIR` was set nowhere, so the DKG wrote verdicts to its relative default (an ephemeral container path) instead of the shared PVC.
2. The QLever rebuild glob enumerated the dirs and omitted the validity one, so even verdict files on the PVC would not be indexed.

Collapsing to one root + a recursive glob removes the class of bug: a new per-dataset output type lands in a new subdirectory and is picked up with no manifest change.

## ⚠️ One-time volume migration

The recursive glob indexes every `.nq` beneath `/data`. The existing shared volume still holds the **old** layout (`/data/nq`, `/data/validation/nq`, `/data/provenance/nq`), so after this rolls out both layouts would be indexed until the old dirs are gone. Because most datasets are skipped as “unchanged” on a normal run, the old dirs cannot just be deleted (that would drop their summaries until a full reprocess). Rename them in place once, on the shared volume (e.g. `kubectl exec` into the QLever pod, which mounts `/data`, with the DKG CronJob suspended so nothing writes mid-migration):

```sh
cd /data
mkdir -p summaries
mv nq/*.nq summaries/ 2>/dev/null || true
mv nq/.rebuild summaries/.rebuild 2>/dev/null || true
rm -f nq/_bootstrap.nq; rmdir nq 2>/dev/null || true
for d in validation provenance validity; do
  [ -d "$d/nq" ] && { mv "$d"/nq/*.nq "$d"/ 2>/dev/null || true; rmdir "$d"/nq 2>/dev/null || true; }
done
```

(`validity/nq` was never populated – that is the bug this PR fixes – so it is a no-op.) The commands are idempotent. Do this as part of the same deploy, then trigger a rebuild (`touch /data/summaries/.rebuild`).

## After deploy

1. Confirm the served KG now has verdicts:
   `SELECT (COUNT(*) AS ?n) WHERE { GRAPH ?g { ?m <http://www.w3.org/ns/dqv#isMeasurementOf> <https://def.nde.nl/metric#distribution-rdf-valid> } }`
2. Note: verdicts are only (re)written when an import is **attempted**. Datasets already skipped as “Unchanged since last run” need a full reprocess (a `PIPELINE_VERSION` rotation, i.e. the next DKG release) to repopulate – including LOD Archiefbeschrijvingen.
