### PR TITLE
refactor(dkg): store generated data under /data/output, isolated from QLever's index

### DIFF
--- a/k8s/dataset-knowledge-graph/helmrelease.yaml
+++ b/k8s/dataset-knowledge-graph/helmrelease.yaml
@@ -46,13 +46,15 @@ spec:
           # Output store: the pipeline writes one n-quads file per dataset onto
           # the shared volume, then signals the read-only serving QLever
           # (qlever.yaml) to rebuild from them. No GraphDB; the KG is rebuilt from
-          # these files each run. OUTPUT_DIR is the single root: the pipeline
-          # derives /data/summaries, /data/validation, /data/provenance
+          # these files each run. OUTPUT_DIR is the single root, kept in its own
+          # subdirectory so the generated data stays separate from QLever's index
+          # files and logs (which live at the /data root): the pipeline derives
+          # /data/output/summaries, /data/output/validation, /data/output/provenance
           # (skip-gate records, read back from the served endpoint below) and
-          # /data/validity (RDF-validity verdicts) beneath it, and the QLever
-          # rebuild indexes every .nq under it (see qlever.yaml's Qleverfile).
+          # /data/output/validity (RDF-validity verdicts), and the QLever rebuild
+          # indexes every .nq under /data/output (see qlever.yaml's Qleverfile).
           - name: OUTPUT_DIR
-            value: /data
+            value: /data/output
           # The served (read-only) QLever the skip gate queries for the previous
           # run's records. Setting this activates dataset skipping; unset, every
           # dataset is reprocessed.

--- a/k8s/dataset-knowledge-graph/qlever.yaml
+++ b/k8s/dataset-knowledge-graph/qlever.yaml
@@ -104,12 +104,32 @@ spec:
             # writes the index files (index.*) alongside it here.
             cp /config/Qleverfile Qleverfile
 
-            # The pipeline writes here. Only summaries/ must pre-exist: it holds
-            # the bootstrap seed and the rebuild sentinel. The other per-purpose
-            # directories (validation, provenance, validity) are created by the
-            # pipeline when it writes them, and the recursive index glob below
-            # finds whatever exists.
-            mkdir -p summaries
+            # Generated data lives under output/ (its own subdir, separate from
+            # QLever's index files and logs at the working-dir root). Only
+            # output/summaries/ must pre-exist: it holds the bootstrap seed and
+            # the rebuild sentinel. The other dirs (validation, provenance,
+            # validity) are created by the pipeline when it writes them, and the
+            # index glob below finds whatever exists under output/.
+            mkdir -p output/summaries
+
+            # One-time migration to the output/ layout: move generated data out
+            # of the working-dir root and drop the legacy `nq` segment. Idempotent
+            # (a no-op once the legacy dirs are gone). Remove in a later cleanup
+            # once every environment has migrated.
+            if [ -d nq ]; then
+              mv nq/*.nq output/summaries/ 2>/dev/null || true
+              mv nq/.rebuild output/summaries/.rebuild 2>/dev/null || true
+              rm -f nq/_bootstrap.nq
+              rmdir nq 2>/dev/null || true
+            fi
+            for legacy in validation provenance validity; do
+              if [ -d "$legacy/nq" ]; then
+                mkdir -p "output/$legacy"
+                mv "$legacy"/nq/*.nq "output/$legacy"/ 2>/dev/null || true
+                rmdir "$legacy/nq" "$legacy" 2>/dev/null || true
+              fi
+            done
+            rmdir summaries 2>/dev/null || true
 
             start_server() {
               qlever start
@@ -122,9 +142,9 @@ spec:
             # graph. The server can then start and serve (empty of datasets)
             # instead of failing on a missing index. It is removed again as soon
             # as real n-quads exist, so it never appears in a populated index.
-            BOOTSTRAP=summaries/_bootstrap.nq
+            BOOTSTRAP=output/summaries/_bootstrap.nq
             seed_if_empty() {
-              if find . -name '*.nq' ! -name '_bootstrap.nq' \
+              if find output -name '*.nq' ! -name '_bootstrap.nq' \
                    -print -quit 2>/dev/null | grep -q .; then
                 rm -f "$BOOTSTRAP"
               else
@@ -179,7 +199,7 @@ spec:
               start_server
             }
 
-            SENTINEL=/data/summaries/.rebuild
+            SENTINEL=/data/output/summaries/.rebuild
             last_scheduled_day=""
             echo "Watching $SENTINEL; daily fallback rebuild at 01:00 $TZ"
             while true; do
@@ -285,25 +305,26 @@ spec:
 
             [index]
             # CAT_INPUT_FILES is the actual data fed to the indexer: every .nq
-            # anywhere beneath the output root (cwd is the shared volume). The
-            # pipeline writes one named graph per analysed dataset under
-            # summaries/, validation/ (SHACL reports), provenance/ (the records
-            # the skip gate reads back) and validity/ (RDF-validity verdicts).
-            # A recursive `find` indexes every output type without enumerating
-            # directories here, so a new per-dataset output dir is picked up with
-            # no change to this file; matching on the `.nq` extension also means
-            # the Turtle inspection copies are skipped. It tolerates a cold or
-            # partial cache.
+            # under output/ (cwd is the shared volume; QLever's own index files
+            # live at the root, outside output/, so the glob never walks them).
+            # The pipeline writes one named graph per analysed dataset under
+            # output/summaries/, output/validation/ (SHACL reports),
+            # output/provenance/ (the records the skip gate reads back) and
+            # output/validity/ (RDF-validity verdicts). A recursive `find` over
+            # output/ indexes every output type without enumerating directories
+            # here, so a new per-dataset output dir is picked up with no change to
+            # this file; matching on the `.nq` extension also means the Turtle
+            # inspection copies are skipped. It tolerates a cold or partial cache.
             #
             # INPUT_FILES is only qlever-control's pre-flight existence check (run
             # BEFORE CAT_INPUT_FILES); if any of its globs matches zero files the
             # build aborts with "Did you call qlever get-data?". So it is a SINGLE
-            # pattern over summaries/, which the bootstrap seed keeps non-empty —
-            # listing the other dirs here too would abort whenever one is empty
-            # (cold start, or a run with no validation reports yet), even though
-            # CAT_INPUT_FILES handles them fine.
-            INPUT_FILES      = summaries/*.nq
-            CAT_INPUT_FILES  = find . -name '*.nq' -exec cat {} +
+            # pattern over output/summaries/, which the bootstrap seed keeps
+            # non-empty — listing the other dirs here too would abort whenever one
+            # is empty (cold start, or a run with no validation reports yet), even
+            # though CAT_INPUT_FILES handles them fine.
+            INPUT_FILES      = output/summaries/*.nq
+            CAT_INPUT_FILES  = find output -name '*.nq' -exec cat {} +
             SETTINGS_JSON    = { "ascii-prefixes-only": false, "num-triples-per-batch": 100000 }
             TEXT_INDEX       = none
 


### PR DESCRIPTION
## What

Move the DKG's generated n-quads from the `/data` root into a `/data/output/` subdirectory:

- **`helmrelease.yaml`**: `OUTPUT_DIR: /data` → `/data/output`. The pipeline derives `/data/output/{summaries,validation,provenance,validity}`.
- **`qlever.yaml`**: scope the rebuild to `find output -name '*.nq'` (and move the bootstrap seed, sentinel and `INPUT_FILES` under `output/`). QLever's working dir stays `/data`, so its `index.*`, `Qleverfile` and `previous.*` backups remain at the root — now cleanly separated from our data, and the glob no longer walks them.

No DKG code change: `config.ts` already derives every directory from `OUTPUT_DIR`.

## Why

`/data` mixed the generated data with QLever's runtime files (index, logs, index backups). Putting our data in its own subdir separates the two, scopes the index glob to just our files, and insulates each from the other (e.g. an index rebuild's `previous.*` backup no longer sits among the data files).

## Migration — automatic

The QLever startup contains a **one-time idempotent migration block** that moves any legacy layout (the old `nq/` dirs from before #249, which had not yet been migrated) into `output/` on the next pod restart. So there is **no manual `kubectl exec` / `mv`** to run — this supersedes the migration runbook on #249. The block is a no-op once migrated; remove it in a later cleanup once every environment has run it.

## Ordering / safety

- The cronjob already runs the `OUTPUT_DIR`-aware image (1.4.0 is `:latest`), so it will write to `/data/output` on its next run.
- On deploy, the QLever pod restarts → runs the migration → re-indexes from `output/` → keeps serving (no data move needed by hand, no downtime beyond the normal rebuild).
- Follow-up (not in this PR): the index could later move to its **own** PVC (it is fully rebuildable, so an empty volume just rebuilds on boot). Deferred deliberately.
