### PR TITLE
fix: load whichever RDF serialization the geonames zip contains

### DIFF
--- a/k8s/geonames-sparql/indexer.yaml
+++ b/k8s/geonames-sparql/indexer.yaml
@@ -64,7 +64,7 @@ spec:
                 - |
                   set -e
                   rm -rf /data/*
-                  # Do all bulk work (download, unzipped TTL, xloader temp files) on the
+                  # Do all bulk work (download, unzipped RDF, xloader temp files) on the
                   # node-local scratch emptyDir, so the 50Gi data PVC only has to hold the
                   # live production index plus the freshly built staging index.
                   cd /scratch
@@ -83,7 +83,12 @@ spec:
                   cp /usr/bin/sort /usr/bin/sort.real
                   printf '%s\n' '#!/bin/sh' 'set -f' 'n=""' 'for a in "$@"; do' '  case "$a" in --buffer-size=*) ;; *) n="$n $a" ;; esac' 'done' 'exec /usr/bin/sort.real $n -S 1G' > /usr/bin/sort
                   chmod +x /usr/bin/sort
-                  tdb2.xloader --loc /data/tdb --tmpdir /scratch/tmp /scratch/geonames.ttl
+                  # The published geonames.zip may contain N-Triples (geonames.nt) or, for
+                  # older builds, Turtle (geonames.ttl). Load whichever is present; tdb2.xloader
+                  # infers the RDF syntax from the file extension.
+                  RDF_FILE=$(ls geonames.nt geonames.ttl 2>/dev/null | head -n1)
+                  [ -n "$RDF_FILE" ] || { echo "No geonames.nt or geonames.ttl found in zip"; exit 1; }
+                  tdb2.xloader --loc /data/tdb --tmpdir /scratch/tmp "/scratch/$RDF_FILE"
                   # Make the TDB2 store group-writable so the Fuseki server (group 100 via
                   # fsGroup) can open it read-write after the swap. Done here because xloader
                   # writes the files as root (this image's default user).
@@ -153,7 +158,7 @@ spec:
             - name: fuseki-config
               configMap:
                 name: geonames-sparql-fuseki-config
-            # Node-local scratch for download + unzipped TTL + xloader sort files.
+            # Node-local scratch for download + unzipped RDF + xloader sort files.
             # sizeLimit bounds it so an overflow evicts only this pod, not the node.
             - name: scratch
               emptyDir:

--- a/k8s/geonames-sparql/reindex-job.yaml
+++ b/k8s/geonames-sparql/reindex-job.yaml
@@ -62,7 +62,7 @@ spec:
               # once inspected (or it self-exits after the sleep).
               fail() { echo "### prepare-tdb FAILED at: $1 (rc=$?) — holding pod 2h for log inspection ###"; sleep 7200; exit 1; }
               rm -rf /data/* || fail "rm staging"
-              # Do all bulk work (download, unzipped TTL, xloader temp files) on the
+              # Do all bulk work (download, unzipped RDF, xloader temp files) on the
               # node-local scratch emptyDir, so the 50Gi data PVC only has to hold the
               # live production index plus the freshly built staging index.
               cd /scratch || fail "cd scratch"
@@ -81,7 +81,12 @@ spec:
               cp /usr/bin/sort /usr/bin/sort.real || fail "cp sort"
               printf '%s\n' '#!/bin/sh' 'set -f' 'n=""' 'for a in "$@"; do' '  case "$a" in --buffer-size=*) ;; *) n="$n $a" ;; esac' 'done' 'exec /usr/bin/sort.real $n -S 1G' > /usr/bin/sort || fail "shadow sort"
               chmod +x /usr/bin/sort || fail "chmod sort"
-              tdb2.xloader --loc /data/tdb --tmpdir /scratch/tmp /scratch/geonames.ttl || fail "xloader"
+              # The published geonames.zip may contain N-Triples (geonames.nt) or, for older
+              # builds, Turtle (geonames.ttl). Load whichever is present; tdb2.xloader infers
+              # the RDF syntax from the file extension.
+              RDF_FILE=$(ls geonames.nt geonames.ttl 2>/dev/null | head -n1)
+              [ -n "$RDF_FILE" ] || fail "no geonames.nt or geonames.ttl in zip"
+              tdb2.xloader --loc /data/tdb --tmpdir /scratch/tmp "/scratch/$RDF_FILE" || fail "xloader"
               # Make the TDB2 store group-writable so the Fuseki server (group 100 via
               # fsGroup) can open it read-write after the swap. Done here because xloader
               # writes the files as root (this image's default user).
@@ -145,7 +150,7 @@ spec:
         - name: fuseki-config
           configMap:
             name: geonames-sparql-fuseki-config
-        # Node-local scratch for download + unzipped TTL + xloader sort files.
+        # Node-local scratch for download + unzipped RDF + xloader sort files.
         # sizeLimit bounds it so an overflow evicts only this pod, not the node.
         - name: scratch
           emptyDir:


### PR DESCRIPTION
## What

Make the `geonames-sparql` TDB2 loader pick whichever RDF file the published `geonames.zip` contains, instead of hardcoding `geonames.ttl`. Applies to both the `indexer.yaml` and `reindex-job.yaml` jobs:

```sh
RDF_FILE=$(ls geonames.nt geonames.ttl 2>/dev/null | head -n1)
[ -n "$RDF_FILE" ] || fail "no geonames.nt or geonames.ttl in zip"
tdb2.xloader --loc /data/tdb --tmpdir /scratch/tmp "/scratch/$RDF_FILE"
```

`tdb2.xloader` infers the RDF syntax from the file extension, so `geonames.nt` loads as N-Triples with no other change. If neither file is present the job fails loudly rather than building an empty index.

## Why

`netwerk-digitaal-erfgoed/geonames-rdf` is switching its published output from Turtle (`geonames.ttl`) to N-Triples (`geonames.nt`) inside the same `geonames.zip` at the same URL (see geonames-rdf#33). The loader previously hardcoded `/scratch/geonames.ttl`, so the first `.nt` harvest would have broken the (re)index with a missing-file error.

Selecting the file at load time **decouples the loader from the publisher**: the zip contents can switch from Turtle to N-Triples (or back) without a coordinated, time-windowed rollout between the two repos. The currently published zip still contains `geonames.ttl`, and this change keeps loading it until the first `.nt` harvest (next scheduled run Sunday 03:00 UTC).

## Verification

- YAML parses (both manifests).
- The embedded loader script passes `sh -n`.
- Glob precedence checked against all four cases: both files present → `.nt`; only `.ttl` → `.ttl`; only `.nt` → `.nt`; neither → guarded failure.
