### PR TITLE
feat(dataset-register): add Valkey store for the detail-page analysis cache

### DIFF
--- a/k8s/dataset-register/browser.yaml
+++ b/k8s/dataset-register/browser.yaml
@@ -41,6 +41,11 @@ spec:
               secretKeyRef:
                 name: dataset-register-typesense
                 key: search-only-api-key
+          # Enables the detail-page Knowledge Graph analysis cache (see the
+          # dataset-register app). The cache is opt-in: it is only active when
+          # VALKEY_URL is set, so it stays bypassed anywhere this is absent.
+          - name: VALKEY_URL
+            value: "redis://dataset-register-valkey:6379"
     ingresses:
       - hosts:
           - datasetregister.netwerkdigitaalerfgoed.nl

--- a/k8s/dataset-register/valkey.yaml
+++ b/k8s/dataset-register/valkey.yaml
@@ -1,0 +1,69 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dataset-register-valkey
+spec:
+  serviceAccountName: nde
+  interval: 30m
+  chart:
+    spec:
+      chart: helm/nde-app
+      reconcileStrategy: Revision
+      sourceRef:
+        kind: GitRepository
+        name: nde
+  values:
+    # Stateful so the cache survives pod restarts (the cross-deployment
+    # durability we want): the browser pods roll on each deploy, this does not.
+    workload:
+      type: statefulset
+
+    service:
+      port: 6379
+
+    containers:
+      - name: app
+        image:
+          repository: valkey/valkey
+          tag: "8.1-alpine"
+        port: 6379
+        # Bounded LRU cache: append-only persistence so it survives restarts, and
+        # a maxmemory below the container limit with allkeys-lru so Valkey evicts
+        # under pressure instead of the pod being OOM-killed (cf. the QLever
+        # soft-cap-below-cgroup lesson). Data is non-sensitive (public dataset
+        # analysis), so no auth on this internal-only service.
+        command:
+          - valkey-server
+          - "--appendonly"
+          - "yes"
+          - "--maxmemory"
+          - "200mb"
+          - "--maxmemory-policy"
+          - "allkeys-lru"
+        resources:
+          requests:
+            cpu: "50m"
+            memory: 64Mi
+          limits:
+            cpu: "250m"
+            memory: 256Mi
+        readinessProbe:
+          exec:
+            command: ["valkey-cli", "ping"]
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          exec:
+            command: ["valkey-cli", "ping"]
+          timeoutSeconds: 5
+          failureThreshold: 3
+        volumeMounts:
+          - name: data
+            mountPath: /data
+
+    persistentVolumes:
+      - name: data
+        size: 1Gi
+
+    # No ingress: the store is internal only. The browser pods connect over the
+    # cluster service DNS at `redis://dataset-register-valkey:6379`.


### PR DESCRIPTION
## What

Adds a **Valkey** store for the dataset-register detail-page Knowledge Graph analysis cache, and wires the browser to it.

- `valkey.yaml` — internal-only Valkey statefulset (`dataset-register-valkey`) as a bounded LRU cache:
  - append-only persistence so it survives pod rolls (cross-deployment durability),
  - `--maxmemory 200mb --maxmemory-policy allkeys-lru` under a 256Mi limit, so it evicts rather than being OOM-killed,
  - 1Gi PVC, `valkey-cli ping` probes, no ingress, no auth (public data, not exposed).
- `browser.yaml` — `VALKEY_URL=redis://dataset-register-valkey:6379`.

## Rollout safety

The app cache is **opt-in on `VALKEY_URL`**, so the rollout order is safe in any sequence: the store without wiring is idle, and the wiring is ignored by any browser image that predates the cache code. Requires the dataset-register app change (netwerk-digitaal-erfgoed/dataset-register#2189) to be deployed for the cache to do anything.

## Follow-ups

- Auth (a Valkey password via secret) if we later want defence-in-depth on the internal service.
- Flux image auto-update policy for the Valkey tag (pinned `8.1-alpine` for now).