### PR TITLE
fix(dataset-register): bump Valkey to 9.0-alpine

### DIFF
--- a/k8s/dataset-register/valkey.yaml
+++ b/k8s/dataset-register/valkey.yaml
@@ -25,7 +25,7 @@ spec:
       - name: app
         image:
           repository: valkey/valkey
-          tag: "8.1-alpine"
+          tag: "9.0-alpine"
         port: 6379
         # Bounded LRU cache: append-only persistence so it survives restarts, and
         # a maxmemory below the container limit with allkeys-lru so Valkey evicts


### PR DESCRIPTION
#252 merged with the stale `8.1` default before the version fix landed. This moves the store to the current Valkey **9.0** major line (matches `compose.yaml` in netwerk-digitaal-erfgoed/dataset-register#2189).