### PR TITLE
fix(dataset-register): remove Valkey probes so the statefulset deploys

### DIFF
--- a/k8s/dataset-register/valkey.yaml
+++ b/k8s/dataset-register/valkey.yaml
@@ -47,16 +47,12 @@ spec:
           limits:
             cpu: "250m"
             memory: 256Mi
-        readinessProbe:
-          exec:
-            command: ["valkey-cli", "ping"]
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        livenessProbe:
-          exec:
-            command: ["valkey-cli", "ping"]
-          timeoutSeconds: 5
-          failureThreshold: 3
+        # No probes: the nde-app chart injects an httpGet default and merges it
+        # with any probe we set, producing an invalid dual-handler (httpGet+exec)
+        # that Kubernetes rejects — and Valkey speaks RESP, not HTTP, so httpGet
+        # can't work anyway. Without a readiness probe the pod is Ready once
+        # running (Valkey accepts connections immediately); the browser fails
+        # fast and falls back to a direct fetch if the store is ever unreachable.
         volumeMounts:
           - name: data
             mountPath: /data


### PR DESCRIPTION
The Valkey store has silently failed to deploy since #252. The `nde-app` chart injects an `httpGet` probe default and `mergeOverwrite`s it with any probe we set, so my `exec` probe rendered as an **invalid dual-handler** (`httpGet`+`exec`) probe that Kubernetes rejects — no statefulset, no pod (confirmed: `helm template` shows both handlers; no valkey pod in Loki over 6h). Valkey speaks RESP not HTTP, so `httpGet` can't work regardless.

Drop the probes: the pod is Ready once running (Valkey accepts connections immediately), and the browser fails fast + falls back to a direct fetch if the store is unreachable. `helm template` now renders a valid statefulset.