### PR TITLE
perf(dataset-register): give the browser a full CPU core for SSR

### DIFF
--- a/k8s/dataset-register/browser.yaml
+++ b/k8s/dataset-register/browser.yaml
@@ -21,6 +21,18 @@ spec:
           repository: ghcr.io/netwerk-digitaal-erfgoed/dataset-register/apps-browser
           tag: 20260701185644-cdc139f # {"$imagepolicy": "nde:dataset-register-browser:tag"}
         port: 3000
+        # SSR is CPU-bound (ldkit RDF parse + Svelte render + devalue-serialize of
+        # the ~800 KB detail page). The SURF LimitRange default of 250m throttled
+        # the render bursts ~40–70% of active CFS periods, inflating TTFB; give it a
+        # full core to burst into. Memory peaks ~150 MiB / 256 over 7d with no OOM,
+        # so only CPU is raised (Typesense uses the same 250m→1 shape).
+        resources:
+          requests:
+            cpu: "250m"
+            memory: 128Mi
+          limits:
+            cpu: "1"
+            memory: 256Mi
         env:
           - name: PROTOCOL_HEADER
             value: "x-forwarded-proto"


### PR DESCRIPTION
SSR on the detail page is CPU-bound (ldkit RDF parse + Svelte render + `devalue`-serialize of the ~800 KB page). Prometheus shows the browser pod throttled **~40–70% of active CFS periods** against the SURF LimitRange default of **250m** — that throttling is the main driver of the ~1s shell TTFB.

Raise the CPU **limit to 1 core** (request 250m) so the render bursts run unthrottled. Memory peaks ~150 MiB / 256 over 7d with **zero OOMKilled and 0 restarts**, so it stays at the default. Same 250m→1 shape Typesense already uses (so the LimitRange allows it).

Will monitor `container_cpu_cfs_throttled` after rollout to confirm it drops.