### PR TITLE
perf(dataset-register): raise browser CPU limit to 2 cores

### DIFF
--- a/k8s/dataset-register/browser.yaml
+++ b/k8s/dataset-register/browser.yaml
@@ -23,15 +23,16 @@ spec:
         port: 3000
         # SSR is CPU-bound (ldkit RDF parse + Svelte render + devalue-serialize of
         # the ~800 KB detail page). The SURF LimitRange default of 250m throttled
-        # the render bursts ~40–70% of active CFS periods, inflating TTFB; give it a
-        # full core to burst into. Memory peaks ~150 MiB / 256 over 7d with no OOM,
-        # so only CPU is raised (Typesense uses the same 250m→1 shape).
+        # the render bursts ~40–70% of active CFS periods, inflating TTFB. At a 1-core
+        # limit throttling dropped to ~20% and TTFB median ~1s→~0.44s; raise to 2
+        # cores (as QLever uses) to give the bursts more headroom. Memory peaks
+        # ~150 MiB / 256 over 7d with no OOM, so only CPU is raised.
         resources:
           requests:
             cpu: "250m"
             memory: 128Mi
           limits:
-            cpu: "1"
+            cpu: "2"
             memory: 256Mi
         env:
           - name: PROTOCOL_HEADER


### PR DESCRIPTION
Follow-up to netwerk-digitaal-erfgoed/infrastructure#255. At a 1-core limit the SSR bursts still throttled ~20% (TTFB median ~0.44s). Raise to 2 cores (QLever already uses 2) to give the render bursts more headroom and push throttling toward zero. Memory unchanged. Will re-measure throttle after rollout.