### PR TITLE
feat(dataset-register): route /changes to the browser app

### DIFF
--- a/k8s/dataset-register/browser.yaml
+++ b/k8s/dataset-register/browser.yaml
@@ -67,6 +67,8 @@ spec:
             pathType: Prefix
           - path: /datasets
             pathType: Prefix
+          - path: /changes
+            pathType: Prefix
           - path: /_app
             pathType: Prefix
           - path: /en


### PR DESCRIPTION
## Summary
- Adds `/changes` to the dataset-register browser app's ingress paths, alongside `/dataset`/`/datasets`.
- Companion to the dataset-register PR that adds a public changelog page at that path — without this, the path falls through to the legacy app.