### PR TITLE
fix(mattermost): correct SMTP auth env var name

### DIFF
--- a/k8s/mattermost/helmrelease.yaml
+++ b/k8s/mattermost/helmrelease.yaml
@@ -40,7 +40,7 @@ spec:
                 key: datasource
           - name: MM_EMAILSETTINGS_SENDEMAILNOTIFICATIONS
             value: "true"
-          - name: MM_EMAILSETTINGS_SMTPAUTH
+          - name: MM_EMAILSETTINGS_ENABLESMTPAUTH
             value: "true"
           - name: MM_EMAILSETTINGS_SMTPSERVER
             value: smtp.lettermint.co


### PR DESCRIPTION
#179 added `MM_EMAILSETTINGS_SMTPAUTH`, but Mattermost’s config setting is `EmailSettings.EnableSMTPAuth`, so the correct env var is `MM_EMAILSETTINGS_ENABLESMTPAUTH`. Mattermost silently ignores unknown env vars, leaving SMTP auth at its default (`false`): it connected to Lettermint without credentials and mail was rejected with “550 Authentication required”.

Renaming the variable makes Mattermost authenticate with the existing `mattermost-smtp` secret. Verified against the [Mattermost environment variables docs](https://docs.mattermost.com/administration-guide/configure/environment-variables.html) and confirmed working by toggling the same setting in the System Console (“Test connection” succeeds).
