### PR TITLE
feat(mattermost): store config in Postgres, enable email invitations

### DIFF
--- a/k8s/mattermost/helmrelease.yaml
+++ b/k8s/mattermost/helmrelease.yaml
@@ -31,6 +31,16 @@ spec:
         env:
           - name: MM_SERVICESETTINGS_SITEURL
             value: https://chat.netwerkdigitaalerfgoed.nl
+          # Store configuration in Postgres so System Console changes survive
+          # pod restarts (config.json is not on a persistent volume). Env vars
+          # still override the database store, 12-factor style.
+          - name: MM_CONFIG
+            valueFrom:
+              secretKeyRef:
+                name: mattermost-postgres
+                key: datasource
+          - name: MM_SERVICESETTINGS_ENABLEEMAILINVITATIONS
+            value: "true"
           - name: MM_SQLSETTINGS_DRIVERNAME
             value: postgres
           - name: MM_SQLSETTINGS_DATASOURCE


### PR DESCRIPTION
Mattermost writes System Console changes to `config.json`, which lives on the ephemeral container filesystem (only `/mattermost/data` is on a persistent volume). Every rollout therefore silently reset all console-made settings to their defaults – this bit us today when “Enable email invitations” reverted after the SMTP fix rollout.

Two changes:

- **Store configuration in Postgres**: `MM_CONFIG` now points at the existing Postgres datasource, so Mattermost uses its [database configuration store](https://docs.mattermost.com/administration-guide/configure/configuration-in-your-database.html) and console changes survive restarts. Environment variables keep precedence over the database store, so GitOps-managed settings (SMTP, site URL, etc.) remain authoritative, 12-factor style.
- **`MM_SERVICESETTINGS_ENABLEEMAILINVITATIONS=true`**: codify the email-invitations setting (default `false`) that was previously toggled via the console and lost on restart.
