### PR TITLE
feat(mattermost): mirror file storage to SURF object store

### DIFF
--- a/k8s/mattermost/s3-mirror-job.yaml
+++ b/k8s/mattermost/s3-mirror-job.yaml
@@ -1,0 +1,56 @@
+# One-off job that mirrors Mattermost's local file storage to the SURF object
+# store, in preparation for switching FileSettings to the amazons3 driver.
+# Mattermost stores file paths relative to the storage root, so a 1:1 mirror of
+# /mattermost/data into the bucket root is all that's needed.
+#
+# Re-run after the S3 cutover (edit + force annotation, see
+# https://fluxcd.io/flux/components/kustomize/kustomizations/#force) to catch
+# files uploaded between the first mirror and the cutover; mc mirror is
+# incremental.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mattermost-s3-mirror
+  namespace: nde
+spec:
+  template:
+    spec:
+      # The data volume is ReadWriteOnce, so this pod must run on the same
+      # node as the Mattermost pod that has it mounted.
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: mattermost
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - name: mirror
+          image: minio/mc:latest
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              export MC_HOST_surf="https://${S3_KEY}:${S3_SECRET}@objectstore.surf.nl"
+              mc mirror --overwrite --summary /data surf/mattermost
+          env:
+            - name: S3_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: s3
+                  key: key
+            - name: S3_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: s3
+                  key: secret
+          volumeMounts:
+            - name: data
+              mountPath: /data
+              readOnly: true
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: data-mattermost-0
+      restartPolicy: OnFailure

--- a/k8s/secrets/s3.yaml
+++ b/k8s/secrets/s3.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+data:
+    key: ENC[AES256_GCM,data:HyAknv6Woxg3zQajw9JDoNaEqRMtJFVrkuCSYZcIZGLtqSkEiq8Hkxf4cwI=,iv:/KD4VnAJY+IF3Vt1W9MV6QLEKHk5g4oDPDTcjiM5sWk=,tag:jkeLkR3R6Sts9eeS0PI4PQ==,type:str]
+    secret: ENC[AES256_GCM,data:xKqwDZugCDG5bwihQHugj/hFy45WsNjalUo88Mb3lPoOhs0QwK1wy83Gh2M=,iv:lRRiijg+KUoB1n2tD6//ljtV3mqQBrNw3GeEBLOu5Hs=,tag:L4GK6upG+Ur/q+rbLkxusg==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: s3
+    namespace: nde
+sops:
+    age:
+        - recipient: age1qnjmyern7zmm5wpsclrpexu327xuqalpcthuk32hj8xn5ssts96s5hhhu8
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxcUdGRzV6TzR6bkVFQUpI
+            bndRbS9rdlFSRTZkbTNiekJFTGpLN0JSNGcwCllPOXNJcU0zWENVaE02N3U0OWtx
+            b3hRUCtLMlVHMXZJcXd4amJ3Ym1pcU0KLS0tIEZ0SVgvNEQyNFc3S05sbnBjTDBh
+            SnY4RFVwZE5pOUozZ1pGeWtYbkNkOEEKxzKt2IWsD9WFvj6bag2j6pZNSUrRtBsg
+            5hyp+6lG9YXyyzJ7zZN/rhLV3Af+fRozXFfnzx15hZ6AMMdJUmS2ZQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-03T09:48:17Z"
+    mac: ENC[AES256_GCM,data:AUgE43ffiTIl3vlb2O60kI7G4MOv2J2/UlyBo07POFUrj0dnfc4UG3dEG7QbixPUUpf+JYigDeOo7OtzgM0QNADT/hRMFKB6TUcz6LoI3YjS+CpWKw5FpN8iSJITSTIqpSHg+KhVxXe5yXa4QEnNSDnMj/Q62Yb6RPf8OjvUjtc=,iv:KNc+OV/EgXyxQZ22ivjcHwPfw8s12xqh8WxtN1iGT44=,tag:mLxctIc3sPR6ewj3u1EyGw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2


### PR DESCRIPTION
First step of moving Mattermost's file storage to the SURF object store (#66), so the app can eventually run as a stateless Deployment with zero-downtime rolling updates.

- **`s3` secret** (sops-encrypted): the SURF object store account credentials. Named generically because the key is account-wide, not Mattermost-specific; SURF's endpoint has no self-service IAM (`MethodNotAllowed`), so a scoped per-app key would have to be issued by SURF – we can swap it in later.
- **`mattermost-s3-mirror` Job**: mirrors `/mattermost/data` from the PVC to the `mattermost` bucket (already created) using `mc mirror`. Mattermost stores file paths relative to the storage root, so a 1:1 mirror is the entire migration. Pod affinity pins the job to the Mattermost pod's node because the volume is ReadWriteOnce.

No behaviour change for Mattermost itself. The `FileSettings` cutover to the `amazons3` driver follows in a separate PR once the mirror has completed, together with a forced re-run of this job to catch files uploaded in between (`mc mirror` is incremental).
