### PR TITLE
feat(mattermost): run as stateless Deployment

### DIFF
--- a/k8s/mattermost/helmrelease.yaml
+++ b/k8s/mattermost/helmrelease.yaml
@@ -14,10 +14,6 @@ spec:
         kind: GitRepository
         name: nde
   values:
-    workload:
-      type: statefulset
-    securityContext:
-      fsGroup: 2000
     containers:
       - name: app
         image:
@@ -87,12 +83,6 @@ spec:
               secretKeyRef:
                 name: s3
                 key: secret
-        volumeMounts:
-          - name: data
-            mountPath: /mattermost/data
-    persistentVolumes:
-      - name: data
-        size: 20Gi
     ingresses:
       - hosts:
           - chat.netwerkdigitaalerfgoed.nl


### PR DESCRIPTION
Final step of the S3 migration (#260, #261): Mattermost no longer needs local state – files live on the SURF object store (verified: the mirrored history and a fresh upload both serve from the bucket) and configuration lives in Postgres. This removes the data volume and lets the workload fall back to the chart's default Deployment, with the `fsGroup` that only existed for volume permissions.

Rolling updates become surge-based: the new pod comes up next to the old one before traffic switches, ending the ~2-minute 502 on every config change and image update.

Notes:

- Helm replaces the StatefulSet with a Deployment on upgrade. During the switch both pods briefly run side by side against the same database; Mattermost handles that fine for a transient overlap.
- The orphaned PVC (`data-mattermost-0`) is intentionally left behind as a rollback safety net; it can be cleaned up once we're confident.
