### PR TITLE
feat(mattermost): enable mobile push notifications via TPNS

### DIFF
--- a/k8s/mattermost/helmrelease.yaml
+++ b/k8s/mattermost/helmrelease.yaml
@@ -65,6 +65,15 @@ spec:
             value: noreply@netwerkdigitaalerfgoed.nl
           - name: MM_EMAILSETTINGS_FEEDBACKNAME
             value: Mattermost
+          # Mobile pushes are relayed through Mattermost’s US-hosted TPNS proxy
+          # (required for the official store apps), so strip the payload down
+          # to the sender name only; message contents stay on our server.
+          - name: MM_EMAILSETTINGS_SENDPUSHNOTIFICATIONS
+            value: "true"
+          - name: MM_EMAILSETTINGS_PUSHNOTIFICATIONSERVER
+            value: https://push-test.mattermost.com
+          - name: MM_EMAILSETTINGS_PUSHNOTIFICATIONCONTENTS
+            value: generic_no_channel
           - name: MM_FILESETTINGS_DRIVERNAME
             value: amazons3
           - name: MM_FILESETTINGS_AMAZONS3ENDPOINT


### PR DESCRIPTION
Enables mobile push notifications for chat.netwerkdigitaalerfgoed.nl.

## Context

Push notifications for the official Mattermost mobile apps must be relayed through a Mattermost-hosted push proxy, because Apple/Google only accept pushes signed with the app publisher’s keys. For Team Edition the only available relay is the free TPNS at `push-test.mattermost.com` (US-hosted, no SLA); the production HPNS endpoints – including the Germany-hosted one – require a paid license.

## Privacy

`MM_EMAILSETTINGS_PUSHNOTIFICATIONCONTENTS=generic_no_channel` strips the push payload to the sender name only (the Mattermost default is `full`, which would send message contents through the US proxy). Message bodies never leave our server; the mobile app fetches them directly once tapped.

Settings are pinned via env vars (which override the Postgres config store) so the trade-off is documented in Git and can’t drift through the System Console.

All parameter names and values verified against the [Mattermost docs](https://docs.mattermost.com/administration-guide/configure/push-notification-server-configuration-settings.html) and [`model/config.go`](https://github.com/mattermost/mattermost/blob/master/server/public/model/config.go) (`push-test.mattermost.com` is the source-code default server for unlicensed installs).
