### PR TITLE
fix(dataset-register): add one-off search reindex Job

### DIFF
--- a/k8s/dataset-register/search-reindex-job.yaml
+++ b/k8s/dataset-register/search-reindex-job.yaml
@@ -1,0 +1,54 @@
+# One-off manual reindex of the Typesense `datasets` collection, independent of
+# the crawl schedule. The crawler only rebuilds the search index after a full
+# crawl completes, so a slow or stalled crawl can leave the live index stale — as
+# happened when the `publisher`→`publisherName` search-field rename shipped in the
+# browser before any post-deploy crawl had rebuilt the collection, breaking search.
+#
+# This runs @dataset-register/search-indexer’s standalone entrypoint (a blue/green
+# rebuild, no crawl) from the crawler image, which already bundles the indexer.
+#
+# Jobs are immutable: to re-run, bump `reconcile.fluxcd.io/requestedAt`; the
+# `force` annotation lets Flux replace the completed Job in place.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: dataset-register-search-reindex
+  namespace: nde
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: Enabled
+    reconcile.fluxcd.io/requestedAt: "2026-07-09T21:09:34Z"
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dataset-register-search-reindex
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: reindex
+          image: ghcr.io/netwerk-digitaal-erfgoed/dataset-register/apps-crawler:20260709185245-2d035f8 # {"$imagepolicy": "nde:dataset-register-crawler:tag"}
+          command:
+            - node
+            - node_modules/@dataset-register/search-indexer/dist/main.js
+          env:
+            - name: SPARQL_URL
+              value: "http://dataset-register-qlever"
+            - name: TYPESENSE_HOST
+              value: "dataset-register-typesense"
+            - name: TYPESENSE_PORT
+              value: "8108"
+            - name: TYPESENSE_PROTOCOL
+              value: "http"
+            - name: TYPESENSE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: dataset-register-typesense
+                  key: api-key
+          resources:
+            requests:
+              cpu: "500m"
+              memory: 2Gi
+            limits:
+              cpu: "1"
+              memory: 4Gi


### PR DESCRIPTION
## Why

Public search at https://datasetregister.netwerkdigitaalerfgoed.nl/en/datasets is down. The last DR merge renamed the browser’s Typesense `query_by` field `publisher_search_*` → `publisherName_search_*` to match the new indexer output, and the browser deployed with that rename. But the live `datasets` collection is still the one the *old* indexer built (it only has `publisher_search_*`), so every search now errors:

```
Could not find a field named `publisherName_search_nl` in the schema.
```

The index only rebuilds after a full crawl completes, and the post-deploy crawl has stalled (overlapping hourly rounds), so the collection is stuck stale.

## What

A one-off, re-runnable Job that rebuilds the Typesense `datasets` collection **independently of the crawl** — it runs `@dataset-register/search-indexer`’s standalone entrypoint (a blue/green rebuild, no crawl) from the crawler image, which already bundles the indexer. Once it commits, the already-deployed browser matches the new `publisherName_search_*` fields and search recovers.

- Flux applies it automatically (the `./k8s` Kustomization is recursive).
- Jobs are immutable: to re-run, bump `reconcile.fluxcd.io/requestedAt`; the `force` annotation lets Flux replace the completed Job in place.

## Not covered here (follow-ups)

- The crawler’s overlapping-round meltdown needs a pod restart (`kubectl -n nde rollout restart deployment dataset-register-crawler`) — separate from this Job.
- DR code fixes: add a crawl-overlap guard, decouple the reindex from the crawl schedule, and make search-field renames additive across a deploy.
