### PR TITLE
fix(dataset-register): run the crawler as a one-shot CronJob

### DIFF
--- a/helm/nde-app/templates/cronjob.yaml
+++ b/helm/nde-app/templates/cronjob.yaml
@@ -19,6 +19,9 @@ spec:
       {{- with .backoffLimit }}
       backoffLimit: {{ . }}
       {{- end }}
+      {{- with .activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ . }}
+      {{- end }}
       template:
         metadata:
           labels:

--- a/helm/nde-app/values.yaml
+++ b/helm/nde-app/values.yaml
@@ -115,6 +115,9 @@ cronjobs: []
   #   command: []
   #   args: []
   #   env: []
+  #   concurrencyPolicy: Forbid    # Optional: Allow (default) | Forbid | Replace
+  #   backoffLimit: 1              # Optional
+  #   activeDeadlineSeconds: 3000  # Optional: kill a Job that runs longer than this (watchdog)
   #   restartPolicy: OnFailure  # Optional, defaults to OnFailure
 
 # CNAME DNS records (via ExternalDNS)

--- a/k8s/dataset-register/crawler.yaml
+++ b/k8s/dataset-register/crawler.yaml
@@ -1,3 +1,17 @@
+# Crawls every registration whose REGISTRATION_URL_TTL has expired, then rebuilds
+# the Typesense `datasets` search index, in a single one-shot run. Recurring
+# crawls are scheduled here rather than in-process: the crawler is a batch job
+# that exits between rounds, so two rounds can never run concurrently in one
+# process.
+#
+# `concurrencyPolicy: Forbid` skips a tick while the previous round is still
+# running, and `activeDeadlineSeconds` reaps a wedged round (e.g. a distribution
+# probe stuck on a down provider) well before the next hourly tick — together
+# these prevent the compounding meltdown where stacked rounds contend on QLever
+# and never drain.
+#
+# Reindex on demand: `kubectl -n nde create job --from=cronjob/dataset-register-crawler-app reindex-now`
+# (this runs a full crawl + reindex, not a reindex only).
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -13,12 +27,15 @@ spec:
         kind: GitRepository
         name: nde
   values:
-    containers:
+    cronjobs:
       - name: app
-        image:
-          repository: ghcr.io/netwerk-digitaal-erfgoed/dataset-register/apps-crawler
-          tag: 20260710180411-6514d07 # {"$imagepolicy": "nde:dataset-register-crawler:tag"}
-        port: 3000
+        schedule: "0 * * * *"
+        concurrencyPolicy: Forbid
+        backoffLimit: 1
+        # Watchdog: a healthy round is well under this; a round stuck past 50 min
+        # is killed before the next hourly tick, so a wedge can never block forever.
+        activeDeadlineSeconds: 3000
+        image: ghcr.io/netwerk-digitaal-erfgoed/dataset-register/apps-crawler:20260710180411-6514d07 # {"$imagepolicy": "nde:dataset-register-crawler:tag"}
         env:
           - name: SPARQL_URL
             value: "http://dataset-register-qlever"
@@ -27,8 +44,6 @@ spec:
               secretKeyRef:
                 name: dataset-register-qlever
                 key: access-token
-          - name: CRAWLER_SCHEDULE
-            value: "0 * * * *"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: "http://nde-otel.monitoring.svc.cluster.local:4318"
           - name: TYPESENSE_HOST

--- a/k8s/dataset-register/crawler.yaml
+++ b/k8s/dataset-register/crawler.yaml
@@ -6,7 +6,7 @@
 #
 # `concurrencyPolicy: Forbid` skips a tick while the previous round is still
 # running, and `activeDeadlineSeconds` reaps a wedged round (e.g. a distribution
-# probe stuck on a down provider) well before the next hourly tick — together
+# probe stuck on a down provider) well before the next hourly tick – together
 # these prevent the compounding meltdown where stacked rounds contend on QLever
 # and never drain.
 #


### PR DESCRIPTION
Converts the Dataset Register crawler from an always-on Deployment to a Kubernetes CronJob, moving scheduling — and therefore overlap prevention — out of the app process.

## Why

The crawler scheduled itself in-process with `node-schedule`, which has no overlap guard: a round longer than the interval spawned a second concurrent crawl in the same process, and rounds stacked until they contended on QLever and never drained (see [netwerk-digitaal-erfgoed/dataset-register#2228](https://github.com/netwerk-digitaal-erfgoed/dataset-register/issues/2228)). A CronJob prevents this natively.

## Changes

- **`k8s/dataset-register/crawler.yaml`**: `containers:` → `cronjobs:`, hourly `schedule: "0 * * * *"`.
  - `concurrencyPolicy: Forbid` — skip a tick while the previous round is still running.
  - `activeDeadlineSeconds: 3000` (50 min) — reap a wedged round before the next hourly tick, so a round stuck on a down provider can never block forever or stack.
  - Drop the `CRAWLER_SCHEDULE` env and the vestigial `port: 3000`; the one-shot image crawls, reindexes, flushes metrics and exits.
- **`helm/nde-app`**: additive `activeDeadlineSeconds` passthrough on the cronjob template (with a `values.yaml` doc comment). Backward-compatible — no existing consumer changes behavior.

## Coordination

- Requires the one-shot crawler image from `netwerk-digitaal-erfgoed/dataset-register#2237`. That PR merges first so Flux builds the image; the old image also runs one-shot when `CRAWLER_SCHEDULE` is unset, so ordering is forgiving.
- **Supersedes the standalone reindex CronJob PR (#265):** indexing is folded back into the crawler run, so that separate `reindex.yaml` is no longer needed and its PR should be closed rather than merged.
