### PR TITLE
fix(nde-app): generate Flux image automation for cronjobs

### DIFF
--- a/helm/nde-app/templates/flux-image-policy.yaml
+++ b/helm/nde-app/templates/flux-image-policy.yaml
@@ -33,3 +33,43 @@ spec:
   {{- end }}
 {{- end }}
 {{- end }}
+{{- /*
+  CronJobs need the same ImagePolicy as containers so their `# {"$imagepolicy": …}`
+  markers resolve; see flux-image-repository.yaml. The spec mirrors the container
+  block above (it depends only on .flux and $fluxName, not on the workload kind).
+*/ -}}
+{{- range .Values.cronjobs }}
+{{- $fluxEnabled := ne ((.flux).enabled) false }}
+{{- if and $fluxEnabled .image }}
+{{- $fluxName := include "nde-app.fluxName" (list ((.flux).name) (include "nde-app.fullname" $) .name) }}
+{{- $policyType := (((.flux).policy).type) | default "numerical" }}
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: {{ $fluxName }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "nde-app.labels" $ | nindent 4 }}
+spec:
+  imageRepositoryRef:
+    name: {{ $fluxName }}
+  {{- if eq $policyType "numerical" }}
+  filterTags:
+    pattern: {{ (((.flux).policy).pattern) | default "^(?P<timestamp>[0-9]{14}).*" | squote }}
+    extract: {{ (((.flux).policy).extract) | default "$timestamp" | squote }}
+  policy:
+    numerical:
+      order: {{ (((.flux).policy).order) | default "asc" }}
+  {{- else if eq $policyType "semver" }}
+  {{- if or (((.flux).policy).pattern) (((.flux).policy).extract) }}
+  filterTags:
+    pattern: {{ (((.flux).policy).pattern) | squote }}
+    extract: {{ (((.flux).policy).extract) | squote }}
+  {{- end }}
+  policy:
+    semver:
+      range: {{ (((.flux).policy).range) | squote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/nde-app/templates/flux-image-repository.yaml
+++ b/helm/nde-app/templates/flux-image-repository.yaml
@@ -20,3 +20,32 @@ spec:
   {{- end }}
 {{- end }}
 {{- end }}
+{{- /*
+  CronJobs carry a flat `image: repo:tag` string (not the containers' structured
+  image.repository/tag), so derive the repository by trimming the trailing tag.
+  Without this a cronjob's `# {"$imagepolicy": …}` marker references a policy that
+  never gets generated, and its image freezes at whatever tag was committed.
+*/ -}}
+{{- range .Values.cronjobs }}
+{{- $fluxEnabled := ne ((.flux).enabled) false }}
+{{- if and $fluxEnabled .image }}
+{{- $fluxName := include "nde-app.fluxName" (list ((.flux).name) (include "nde-app.fullname" $) .name) }}
+{{- $repository := regexReplaceAll ":[^:/]+$" .image "" }}
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: {{ $fluxName }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "nde-app.labels" $ | nindent 4 }}
+spec:
+  image: {{ $repository }}
+  {{- $defaultInterval := (hasPrefix "ghcr.io/netwerk-digitaal-erfgoed" $repository) | ternary "1m" "24h" }}
+  interval: {{ ((.flux).interval) | default $defaultInterval }}
+  {{- if or ((.flux).secretRef) (hasPrefix "ghcr.io" $repository) }}
+  secretRef:
+    name: {{ ((.flux).secretRef) | default "ghcr" }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/k8s/dataset-knowledge-graph/helmrelease.yaml
+++ b/k8s/dataset-knowledge-graph/helmrelease.yaml
@@ -28,6 +28,10 @@ spec:
         backoffLimit: 1
         image: ghcr.io/netwerk-digitaal-erfgoed/dataset-knowledge-graph
         imagePullPolicy: Always
+        # Deliberately pulls :latest each run (imagePullPolicy: Always) rather than
+        # a pinned tag, so it is not tracked by Flux image automation.
+        flux:
+          enabled: false
         env:
           - name: QLEVER_ENV
             value: native

--- a/k8s/dataset-register/crawler.yaml
+++ b/k8s/dataset-register/crawler.yaml
@@ -35,7 +35,7 @@ spec:
         # Watchdog: a healthy round is well under this; a round stuck past 50 min
         # is killed before the next hourly tick, so a wedge can never block forever.
         activeDeadlineSeconds: 3000
-        image: ghcr.io/netwerk-digitaal-erfgoed/dataset-register/apps-crawler:20260710180411-6514d07 # {"$imagepolicy": "nde:dataset-register-crawler:tag"}
+        image: ghcr.io/netwerk-digitaal-erfgoed/dataset-register/apps-crawler:20260710180411-6514d07 # {"$imagepolicy": "nde:dataset-register-crawler"}
         env:
           - name: SPARQL_URL
             value: "http://dataset-register-qlever"

--- a/k8s/dataset-register/search-reindex-job.yaml
+++ b/k8s/dataset-register/search-reindex-job.yaml
@@ -27,7 +27,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: reindex
-          image: 20260710180411-6514d07 # {"$imagepolicy": "nde:dataset-register-crawler:tag"}
+          image: ghcr.io/netwerk-digitaal-erfgoed/dataset-register/apps-crawler:20260710180411-6514d07 # {"$imagepolicy": "nde:dataset-register-crawler"}
           command:
             - node
             - node_modules/@dataset-register/search-indexer/dist/main.js

--- a/k8s/openrefine/helmrelease.yaml
+++ b/k8s/openrefine/helmrelease.yaml
@@ -45,6 +45,9 @@ spec:
         schedule: "0 4 * * 6"
         image: alpine:latest
         imagePullPolicy: Always
+        # A pinned utility image, not tracked by Flux image automation.
+        flux:
+          enabled: false
         command:
           - bin/sh
           - -c


### PR DESCRIPTION
Fixes a regression from #266: after the crawler moved to a CronJob, its image stopped auto-updating (frozen at `…180411-6514d07` for ~2 days while api/browser advanced to `…184713-c3a9887`).

## Root cause

The `nde-app` chart generated `ImageRepository`/`ImagePolicy` only for `.Values.containers` (`flux-image-repository.yaml` / `flux-image-policy.yaml` both `range .Values.containers`). Switching the crawler to `.Values.cronjobs` therefore deleted its image policy, so the `# {"$imagepolicy": "nde:dataset-register-crawler"}` marker pointed at a non-existent policy and the tag never bumped.

## Fix

- **Chart:** extend both Flux templates to also `range .Values.cronjobs`. CronJobs carry a flat `image: repo:tag` string (containers have a structured `image.repository`/`tag`), so the repository is derived by trimming the trailing tag. The container blocks are byte-identical to before — api/browser are unaffected. Cronjob image automation is opt-out (default-on), matching containers.
- **Opt out the untracked cronjobs:** with automation default-on, the `openrefine` `clear-projects` (alpine) and `dataset-knowledge-graph` (`:latest`) cronjobs would each get an ImageRepository plus an ImagePolicy whose numerical tag filter matches nothing — a perpetual Flux error for a resource nothing consumes. Disable them with `flux.enabled: false`, the same way the qlever-ui and dkg-qlever containers already do.
- **Markers:** on a flat `image: repo:tag` line the `:tag` setter writes back only the tag and strips the repository — which is exactly what happened to `search-reindex-job.yaml` (its `image:` had decayed to a bare tag). Both the crawler and `search-reindex-job` now use the full-image setter (`…crawler`, no `:tag` suffix), and `search-reindex-job`'s repository is restored.

## Validation

`helm template` confirms: the crawler CronJob now renders its `ImageRepository` (`image: …/apps-crawler`, `interval: 1m`, ghcr secret) and `ImagePolicy` (numerical timestamp); openrefine emits only its container `openrefine` semver policy (no `clear-projects` resource) and dkg emits none; the container-path output for both templates is diff-identical to master.

Once merged, Flux will pick up the #2237 image and the crawler will run the one-shot code with the metrics-flush/SIGTERM handling.
