### PR TITLE
feat(dataset-register): route /graphql to the browser pod for the search API

### DIFF
--- a/k8s/dataset-register/browser.yaml
+++ b/k8s/dataset-register/browser.yaml
@@ -39,10 +39,15 @@ spec:
             value: "x-forwarded-proto"
           - name: HOST_HEADER
             value: "x-forwarded-host"
-          # Typesense search config for the browser. The #2119 browser image has no
-          # SPARQL listing, so these must be present before that image deploys – the
-          # browser stays pinned (see the tag above) until the index is built and
-          # verified, then unpinning deploys the new image onto a ready Typesense.
+          # Expand phase: both the old and new browser image configs are present so
+          # this env is safe under either image. The CURRENT image queries Typesense
+          # directly from the client with the public search-only key (below). The
+          # NEW image (GraphQL search migration) runs the Typesense engine server-side
+          # and reads the private TYPESENSE_* config; the client no longer sees a key.
+          # Contract (a later change) removes the PUBLIC_TYPESENSE_* block once the new
+          # image is live.
+          #
+          # Client-direct config for the current image (public search-only key).
           - name: PUBLIC_TYPESENSE_HOST
             value: "search.datasetregister.netwerkdigitaalerfgoed.nl"
           - name: PUBLIC_TYPESENSE_PROTOCOL
@@ -54,6 +59,21 @@ spec:
               secretKeyRef:
                 name: dataset-register-typesense
                 key: search-only-api-key
+          # Server-side engine config for the new image: the internal Typesense
+          # service (never exposed to the client). The admin key is used because the
+          # engine's in-memory label cache exports the label collections, which the
+          # search-only key cannot do; it stays server-side.
+          - name: TYPESENSE_HOST
+            value: "dataset-register-typesense"
+          - name: TYPESENSE_PROTOCOL
+            value: "http"
+          - name: TYPESENSE_PORT
+            value: "8108"
+          - name: TYPESENSE_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: dataset-register-typesense
+                key: api-key
           # Enables the detail-page Knowledge Graph analysis cache (see the
           # dataset-register app). The cache is opt-in: it is only active when
           # VALKEY_URL is set, so it stays bypassed anywhere this is absent.

--- a/k8s/dataset-register/browser.yaml
+++ b/k8s/dataset-register/browser.yaml
@@ -75,6 +75,10 @@ spec:
             pathType: Prefix
           - path: /proxy
             pathType: Prefix
+          # The GraphQL search API the browser queries same-origin (server-side
+          # engine); the SPA's search is dead in prod without this route.
+          - path: /graphql
+            pathType: Prefix
           - path: /sitemap.xml
             pathType: Prefix
           - path: /robots.txt


### PR DESCRIPTION
Prepares the dataset-register browser pod for netwerk-digitaal-erfgoed/dataset-register#2232, which moves the dataset listing search onto a **server-side** GraphQL endpoint (the Typesense engine now runs in the browser pod; the key is no longer public). Two additive (expand-phase) changes:

1. **Ingress**: allowlist `/graphql` → the browser pod. The ingress only routes specific paths, so without this the deployed SPA’s same-origin `/graphql` fetch would 404.
2. **Env**: add server-side `TYPESENSE_HOST` / `PORT` / `PROTOCOL` / `API_KEY` (internal service `dataset-register-typesense:8108`, **admin** key – the engine’s in-memory label cache uses `documents:export`, which the search-only key lacks; it stays server-side). The old `PUBLIC_TYPESENSE_*` block is **kept** (expand): the config is valid under both the current client-direct image and the new server-engine image.

Verified with `helm template` (rendered-manifest diff): the browser adds only the four `TYPESENSE_*` env vars and the `/graphql` Prefix path – nothing else.

**Safe to merge anytime.** Under the current image, the `TYPESENSE_*` vars are unused and `/graphql` 404s harmlessly. Under the new image, it reads them.

## Rollout – and a caveat about the shared collection

The env/ingress here are expand/contract-clean. The **schema change in #2232 is not**: it rebuilds the shared `datasets` collection with combined `format`/`class` group tokens (dropping `format_group`/`class_group`) and stops writing the old `labels` sidecar. The old (pinned) browser reads that same collection, so after a reindex its group-token facet toggles glitch and labels go stale – **core search keeps working**.

So there is **no** fully-parallel path with #2232 as written. Choose one:

- **(A) Short degraded window**: pin the browser image → merge this PR → run the reindex job (builds the typed label collections + combined-token `datasets`) → verify → unpin. Between reindex and unpin (~10–15 min) the old browser’s group facets glitch; then the new image is live and fully correct.
- **(B) Zero downtime**: first make #2232’s schema additive too – keep `format_group`/`class_group` and keep writing the `labels` sidecar – so the reindex is non-breaking for the old browser; deploy the new image; then a **contract** PR removes the old fields + sidecar.

## Contract (later)

Once the new image is live: remove the `PUBLIC_TYPESENSE_*` block here, and retire the now-unused public `search.datasetregister.netwerkdigitaalerfgoed.nl` Typesense ingress.
