### PR TITLE
fix(dataset-register): pin the browser image for the GraphQL search migration

### DIFF
--- a/k8s/dataset-register/browser.yaml
+++ b/k8s/dataset-register/browser.yaml
@@ -19,7 +19,15 @@ spec:
       - name: app
         image:
           repository: ghcr.io/netwerk-digitaal-erfgoed/dataset-register/apps-browser
-          tag: 20260713115504-ad1b03f # {"$imagepolicy": "nde:dataset-register-browser:tag"}
+          # PINNED for the GraphQL search migration (dataset-register#2232): the
+          # Flux image-policy auto-update marker (normally a trailing comment on the
+          # tag line below) is removed so that merging #2232 does not deploy the new
+          # server-side /graphql browser image before the typed Typesense collections
+          # exist – that would show bare-IRI labels and empty group facets until the
+          # crawler reindexes. To unpin, restore that trailing image-policy marker on
+          # the tag line (the other apps in this repo show the exact syntax) once the
+          # reindex has run and /graphql is verified; Flux then deploys the new image.
+          tag: 20260713115504-ad1b03f
         port: 3000
         # SSR is CPU-bound (ldkit RDF parse + Svelte render + devalue-serialize of
         # the ~800 KB detail page). The SURF LimitRange default of 250m throttled


### PR DESCRIPTION
Pins the dataset-register browser image ahead of the GraphQL search migration (netwerk-digitaal-erfgoed/dataset-register#2232), so merging #2232 does **not** auto-deploy the new server-side `/graphql` browser image before the backend is ready.

Removes the Flux image-policy auto-update marker from the browser image tag (holding it at the current `apps-browser` image). `helm template` renders **identically** – this is a Flux-automation-source change only; the running image is unchanged.

## Why

The new browser image runs the Typesense engine server-side and reads the typed label collections (`organizations` / `classes` / `terminology-sources`) + the combined-token `datasets`. Those are built by the **crawler** (the `apps-crawler` image, which #2232 also updates). If the browser image auto-deployed the moment #2232 merged – before the crawler reindexed – search would show bare-IRI labels and empty `group:*` facet toggles. Pinning holds the old (working) browser until the collections exist.

## Rollout (option A)

1. **Merge this PR** (pins the browser).
2. **Merge #2232** → the new `apps-crawler` image builds and deploys; the browser stays pinned on the old image.
3. **Reindex** → the crawler’s next hourly run (or trigger the `search-reindex` Job for immediacy) rebuilds with the new schema and creates the typed label collections.
4. **Verify** the typed collections exist and `/graphql` responds.
5. **Unpin** → restore the trailing `$imagepolicy` marker on the browser tag line; Flux deploys the new browser image onto the ready backend.

Short window: between the reindex (step 3) and unpin (step 5) the **old** browser’s `group:*` facet toggles glitch and labels are frozen-but-shown; core listing + search keep working.

**Merge order matters:** this pin must land **before** #2232, or the browser auto-deploys prematurely.
