### PR TITLE
fix(dataset-register): unpin the browser image after the GraphQL migration

### DIFF
--- a/k8s/dataset-register/browser.yaml
+++ b/k8s/dataset-register/browser.yaml
@@ -19,15 +19,7 @@ spec:
       - name: app
         image:
           repository: ghcr.io/netwerk-digitaal-erfgoed/dataset-register/apps-browser
-          # PINNED for the GraphQL search migration (dataset-register#2232): the
-          # Flux image-policy auto-update marker (normally a trailing comment on the
-          # tag line below) is removed so that merging #2232 does not deploy the new
-          # server-side /graphql browser image before the typed Typesense collections
-          # exist – that would show bare-IRI labels and empty group facets until the
-          # crawler reindexes. To unpin, restore that trailing image-policy marker on
-          # the tag line (the other apps in this repo show the exact syntax) once the
-          # reindex has run and /graphql is verified; Flux then deploys the new image.
-          tag: 20260713115504-ad1b03f
+          tag: 20260713115504-ad1b03f # {"$imagepolicy": "nde:dataset-register-browser:tag"}
         port: 3000
         # SSR is CPU-bound (ldkit RDF parse + Svelte render + devalue-serialize of
         # the ~800 KB detail page). The SURF LimitRange default of 250m throttled


### PR DESCRIPTION
Unpins the dataset-register browser image now that the GraphQL search migration is ready end to end. Restores the Flux `$imagepolicy` auto-update marker on the browser tag line (and removes the temporary pin comment).

## Why it is safe now

- **Backend reindexed.** The new crawler image deployed and its 18:00 UTC run rebuilt the `datasets` collection on the combined-token schema (2676 docs) and built the typed label collections: `organizations` (309), `terminology-sources` (25). `classes` is skipped because the DKG carries no class labels – the class facet renders from the browser's client-side translation table, as it always has.
- **Fixed browser image is newest.** The first `/graphql` browser image (from dataset-register#2232) crashed on every request (`ERR_UNSUPPORTED_DIR_IMPORT` for `graphql/language`, from the core barrel dragging in comunica). That is fixed by dataset-register#2246, whose image `apps-browser:20260713181431-0f8159e` is published and is the newest `apps-browser` image. Restoring the floating marker therefore makes Flux deploy the **fixed** image, not the broken one.

## Effect

Flux image automation picks `20260713181431-0f8159e`, commits the tag bump to `master`, and rolls out the new server-side `/graphql` browser onto the ready backend. The short degraded window (old browser against the new `datasets` schema – dead `group:*` toggles, stale labels) then ends.

## Follow-ups (separate PRs, not this one)

- **Contract phase:** remove the now-unused `PUBLIC_TYPESENSE_*` client-direct env block and retire the public Typesense search ingress once the new image is confirmed live.
- Unrelated: the `apps-api` push flaked in the same release run (a registry error, not a code failure); `apps-api` simply did not get a new image this cycle and still runs its previous one. A re-run of the release workflow will republish it.
