### PR TITLE
refactor(dataset-register): retire the client-direct Typesense search path

### DIFF
--- a/k8s/dataset-register/browser.yaml
+++ b/k8s/dataset-register/browser.yaml
@@ -39,30 +39,11 @@ spec:
             value: "x-forwarded-proto"
           - name: HOST_HEADER
             value: "x-forwarded-host"
-          # Expand phase: both the old and new browser image configs are present so
-          # this env is safe under either image. The CURRENT image queries Typesense
-          # directly from the client with the public search-only key (below). The
-          # NEW image (GraphQL search migration) runs the Typesense engine server-side
-          # and reads the private TYPESENSE_* config; the client no longer sees a key.
-          # Contract (a later change) removes the PUBLIC_TYPESENSE_* block once the new
-          # image is live.
-          #
-          # Client-direct config for the current image (public search-only key).
-          - name: PUBLIC_TYPESENSE_HOST
-            value: "search.datasetregister.netwerkdigitaalerfgoed.nl"
-          - name: PUBLIC_TYPESENSE_PROTOCOL
-            value: "https"
-          - name: PUBLIC_TYPESENSE_PORT
-            value: "443"
-          - name: PUBLIC_TYPESENSE_SEARCH_ONLY_API_KEY
-            valueFrom:
-              secretKeyRef:
-                name: dataset-register-typesense
-                key: search-only-api-key
-          # Server-side engine config for the new image: the internal Typesense
-          # service (never exposed to the client). The admin key is used because the
-          # engine's in-memory label cache exports the label collections, which the
-          # search-only key cannot do; it stays server-side.
+          # Server-side search engine config: the browser runs the Typesense
+          # engine behind its /graphql endpoint and reads this internal Typesense
+          # service, which is never exposed to the client. The admin key is used
+          # because the engine's in-memory label cache exports the label
+          # collections, which a search-only key cannot do; it stays server-side.
           - name: TYPESENSE_HOST
             value: "dataset-register-typesense"
           - name: TYPESENSE_PROTOCOL

--- a/k8s/dataset-register/typesense.yaml
+++ b/k8s/dataset-register/typesense.yaml
@@ -47,8 +47,6 @@ spec:
               secretKeyRef:
                 name: dataset-register-typesense
                 key: api-key
-          - name: TYPESENSE_ENABLE_CORS
-            value: "true"
         resources:
           requests:
             cpu: "250m"
@@ -76,16 +74,7 @@ spec:
       - name: data
         size: 10Gi
 
-    # The browser queries Typesense directly from the client with the
-    # search-only key, so it needs a publicly reachable HTTPS host. A dedicated
-    # subdomain is used because the Typesense client builds plain
-    # `protocol://host:port` URLs with no base path, so a path-prefix on the
-    # main host would not work. The first ingress gets TLS auto-configured by
-    # the chart. CORS is enabled on the server (TYPESENSE_ENABLE_CORS) so the
-    # browser app on datasetregister.netwerkdigitaalerfgoed.nl can call it.
-    ingresses:
-      - hosts:
-          - search.datasetregister.netwerkdigitaalerfgoed.nl
-        paths:
-          - path: /
-            pathType: Prefix
+    # Typesense is reached only in-cluster by the browser pod's server-side
+    # search engine (via the `dataset-register-typesense` service on 8108), so it
+    # has no ingress. The former public `search.datasetregister…` subdomain and
+    # its search-only key served the retired client-direct search path.


### PR DESCRIPTION
Contract phase of the GraphQL search migration. The browser now runs the Typesense engine server-side behind its `/graphql` endpoint (live in prod as of the browser unpin, #271), so the old client-direct-to-Typesense search path is no longer used. This removes its leftover config.

## Changes

- **`browser.yaml`** – drop the `PUBLIC_TYPESENSE_*` env block (`HOST`, `PROTOCOL`, `PORT`, and the `search-only-api-key`). The client bundle no longer contains a Typesense client or key.
- **`typesense.yaml`** – drop the public `search.datasetregister.netwerkdigitaalerfgoed.nl` ingress and `TYPESENSE_ENABLE_CORS`. Typesense is now reached only in-cluster, by the browser pod's server-side engine via the `dataset-register-typesense` service on `8108`; it needs neither a public host nor cross-origin access.

## Impact / safety

- The public search subdomain only ever served the browser's client-direct path (per the removed comment) – it was an implementation detail, not a documented API. The public search API is now `/graphql` (plus the existing `/api/*` REST). No app change is needed; the browser already queries `/graphql`.
- After merge, Flux drops the ingress (and its TLS). The `search.datasetregister…` DNS record, managed outside this repo, will dangle harmlessly and can be cleaned up separately.
- The `search-only-api-key` entry in the `dataset-register-typesense` secret is now unused but left in place – removing secret keys is a separate, careful step.

No image build is involved; this is a manifest-only change that Flux reconciles.
