### PR TITLE
Changing certificate issuer to harica

### DIFF
--- a/helm/nde-app/values.yaml
+++ b/helm/nde-app/values.yaml
@@ -55,7 +55,7 @@ service:
 # Ingress - shared annotations for ingresses that have TLS enabled.
 ingress:
   annotations:
-    cert-manager.io/issuer: letsencrypt-nde
+    cert-manager.io/cluster-issuer: harica
     cert-manager.io/usages: server auth,digital signature,client auth
     acme.cert-manager.io/http01-edit-in-place: "true"
 


### PR DESCRIPTION
Harica issuer is now able to create certificates for the nde and nederlandsdigitaalerfgoed domains. 
Added as a cluster issuer.